### PR TITLE
Fix bug where consumers were unable to merge PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,3 +11,4 @@ runs:
   image: 'Dockerfile'
   env:
     GITHUB_ACTION_INPUT_LABELS: ${{ inputs.labels }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/agilepathway/label-checker
 
 go 1.14
 
-require github.com/magefile/mage v1.9.0
+require (
+	github.com/magefile/mage v1.9.0
+	github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd
+	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,16 @@
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd h1:EwtC+kDj8s9OKiaStPZtTv3neldOyr98AXIxvmn3Gss=
+github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f h1:tygelZueB1EtXkPI6mQ4o9DQ0+FKW41hTbunoXZCTqk=
+github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
Fixes a bug whereby a PR could show that the check has passed, but
still not allow the pull request to be merged.  This is because GitHub
Actions create a separate new instance of the check for some different
event types, e.g. the `labeled` event creates a new check instance
separate from the `push` event checks.  So if, for instance, a consumer:
1. pushed a commit when there is no required label
2. added the required label
then the `lableled` instance of the check would pass, but the push would
still show the initial failure.
The fix in this commit is to retrieve the GitHub
labels for the pull request via the GitHub API, instead of using the
labels in the GitHub Action's event JSON (which is a frozen snapshot of
the labels at the time of committing and therefore does not stay up to
date with subsequent label changes).  Now if we rerun the failed `push`
job after amending the labels, the check passes.