### PR TITLE
Remove obsolete pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-- [ ] Label the pull request with a [semantic version](https://semver.org/), i.e. one of:
-
-    - `major` (new functionality that is not backwards compatible)
-
-    - `minor` (new functionality that is backwards compatible)
-
-    - `patch` (backwards compatible bug fixes)


### PR DESCRIPTION
It is no longer needed as the label checker will ensure that we cannot
process a pull request unless there is a semantic version label.