### PR TITLE
Tidy the input variables

### DIFF
--- a/.github/workflows/check_semver_labels.yml
+++ b/.github/workflows/check_semver_labels.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: agilepathway/label-checker@master
         with:
-          one-of: >
+          one_of: >
             [
               "major",
               "minor",
               "patch"
             ]
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go test ./...

--- a/action.yml
+++ b/action.yml
@@ -3,31 +3,31 @@ name: 'Label checker for pull requests'
 description: 'Checks pull requests for given labels'
 author: 'John Boyes'
 inputs:
-  one-of:
+  one_of:
     description: >
       A JSON array of labels.
       Each pull request must be labeled with exactly one of these labels.
     required: false
     default: '[]'
-  none-of:
+  none_of:
     description: >
       A JSON array of labels.
       Each pull request must not be labeled with any of these labels.
     required: false
     default: '[]'
-  all-of:
+  all_of:
     description: >
       A JSON array of labels.
       Each pull request must be labeled with all of these labels.
     required: false
     default: '[]'
-  any-of:
+  any_of:
     description: >
       A JSON array of labels.
       Each pull request must be labeled with one or more of these labels.
     required: false
     default: '[]'
-  github-token:
+  repo_token:
     description: >
       See this link for an example of how to pass in the GitHub token:
       https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#example-passing-github_token-as-an-input
@@ -35,9 +35,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  env:
-    LABELS_ONE_REQUIRED: ${{ inputs.one-of }}
-    LABELS_NONE_REQUIRED: ${{ inputs.none-of }}
-    LABELS_ALL_REQUIRED: ${{ inputs.all-of }}
-    LABELS_ANY_REQUIRED: ${{ inputs.any-of }}
-    GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -85,23 +85,23 @@ func (a *Action) pullRequestNumber() int {
 }
 
 func (a *Action) token() string {
-	return os.Getenv("GITHUB_TOKEN")
+	return os.Getenv("INPUT_REPO_TOKEN")
 }
 
 func (a *Action) exactlyOneRequired() []string {
-	return a.getLabelsFromEnvVar("LABELS_ONE_REQUIRED")
+	return a.getLabelsFromEnvVar("INPUT_ONE_OF")
 }
 
 func (a *Action) noneRequired() []string {
-	return a.getLabelsFromEnvVar("LABELS_NONE_REQUIRED")
+	return a.getLabelsFromEnvVar("INPUT_NONE_OF")
 }
 
 func (a *Action) allRequired() []string {
-	return a.getLabelsFromEnvVar("LABELS_ALL_REQUIRED")
+	return a.getLabelsFromEnvVar("INPUT_ALL_OF")
 }
 
 func (a *Action) anyRequired() []string {
-	return a.getLabelsFromEnvVar("LABELS_ANY_REQUIRED")
+	return a.getLabelsFromEnvVar("INPUT_ANY_OF")
 }
 
 func (a *Action) getLabelsFromEnvVar(envVar string) []string {

--- a/label_checker_test.go
+++ b/label_checker_test.go
@@ -15,10 +15,10 @@ import (
 const (
 	EnvGitHubRepository     = "GITHUB_REPOSITORY"
 	EnvGitHubEventPath      = "GITHUB_EVENT_PATH"
-	EnvRequireOneOf         = "LABELS_ONE_REQUIRED"
-	EnvRequireNoneOf        = "LABELS_NONE_REQUIRED"
-	EnvRequireAllOf         = "LABELS_ALL_REQUIRED"
-	EnvRequireAnyOf         = "LABELS_ANY_REQUIRED"
+	EnvRequireOneOf         = "INPUT_ONE_OF"
+	EnvRequireNoneOf        = "INPUT_NONE_OF"
+	EnvRequireAllOf         = "INPUT_ALL_OF"
+	EnvRequireAnyOf         = "INPUT_ANY_OF"
 	GitHubTestRepo          = "agilepathway/test-label-checker-consumer"
 	NoLabelsPR              = 1 // https://github.com/agilepathway/test-label-checker-consumer/pull/1
 	OneLabelPR              = 2 // https://github.com/agilepathway/test-label-checker-consumer/pull/2


### PR DESCRIPTION
Removed the unnecessary manual translation of the input variables into
environment variables, in the action.yml.  It is not needed because
GitHub actions automatically create environment variables for the input
variables.[1]

NB The manual translation would not work when we move to a minimal
pre-built Docker image (#22).

Also renamed the inputs to have underscores instead of dashes, as
dashes are not valid POSIX standard names.[2]
(This caused a problem as I could not set these environment variables
when running the tests, causing the tests to fail.)
(I fed back to GitHub (via their feedback form [3]) that they may want
to convert dashes to underscores when converting the input variables to
environment variables.)

[1] https://help.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
[2] https://stackoverflow.com/a/36992531
[3] https://support.github.com/contact/feedback?contact%5Bcategory%5D=actions