### PR TITLE
Fix Docker semantic version tagging

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -1,8 +1,7 @@
 ---
 name: Docker
 on:  # yamllint disable-line rule:truthy
-  push
-
+  [push, create]
 
 jobs:
 


### PR DESCRIPTION
Run the Docker build and push on "create" as well as "push", so that it
is triggered when the tag is created (by the semver-release-action).