### PR TITLE
Speed up label checking by making binary smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN scripts/install-mage.sh
 
-RUN CGO_ENABLED=0 mage -compile /bin/check-labels -goos linux -goarch amd64
+RUN CGO_ENABLED=0 GOFLAGS=-ldflags="-w" mage -compile /bin/check-labels -goos linux -goarch amd64
 
 
 # Use the most basic and empty container - this container has no


### PR DESCRIPTION
This commit removes the DWARF debugging information[1], resulting in the
Docker image size shrinking from 4.76MB to 2.88MB.

Decided not to try to also turn off generation of the Go symbol table
using the `-s` flag, as:
1. the GOFLAGS functionality currently only allows 1 ldflag to be set[2]
   (NB this may be fixed in Go 1.15[3])
2. The improvements to the binary size in Go 1.15 [4] mean that the `-s`
   flag will no longer really do anything[5]

Will also try shrinking the binary size further using upx[6] in a
separate pull request.

[1] https://stackoverflow.com/a/22276273
[2] https://github.com/golang/go/issues/38522
[3] https://github.com/golang/go/issues/26849#issuecomment-615953358
[4] See #64
[5] https://twitter.com/bradfitz/status/1256989624590712834
[6] https://upx.github.io/