### PR TITLE
Speed up label checking using UPX to shrink binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ RUN scripts/install-mage.sh
 
 RUN CGO_ENABLED=0 GOFLAGS=-ldflags="-w" mage -compile /bin/check-labels -goos linux -goarch amd64
 
+# Compress the compiled action using UPX (https://upx.github.io/) 
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get -y install --no-install-recommends upx
+RUN upx -q -9 /bin/check-labels
 
-# Use the most basic and empty container - this container has no
-# runtime, files, shell, libraries, etc.
+# Use the most basic and empty container - no runtime, files, shell, libraries, etc.
 FROM scratch
 
 # We need the ssl certs for when we make an https call to the GitHub API


### PR DESCRIPTION
This shrinks the binary size from 2.88MB to 2.7MB (not a huge drop, but
still worth doing nonetheless).

UPX: https://upx.github.io/

As per this example from Seth Vargo[1]

Filippo Valsorda also has a good explanation of this technique[2]

[1] https://www.sethvargo.com/writing-github-actions-in-go/
[2] https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/