### PR TITLE
Speed up label checking by stripping symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN scripts/install-mage.sh
 
 RUN CGO_ENABLED=0 GOFLAGS=-ldflags="-w" mage -compile /bin/check-labels -goos linux -goarch amd64
 
+# Strip any symbols - this is not a library
+RUN strip /bin/check-labels
+
 # Compress the compiled action using UPX (https://upx.github.io/) 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get -y install --no-install-recommends upx


### PR DESCRIPTION
This reduces the binary size from 2.7MB to 2.57MB (not a huge drop, but
worth doing nonetheless)

Using the strip command as per this example:
https://www.sethvargo.com/writing-github-actions-in-go/

This post[1] suggests that the Go team do not recommend doing this, as
it may break the executable.  Still going ahead though, we can always
revert this change if we encounter any problems.

[1] https://stackoverflow.com/questions/30005878/avoid-debugging-information-on-golang#comment48168448_30007760