### PR TITLE
Use the new comma-separated label inputs

### DIFF
--- a/.github/workflows/check_semver_labels.yml
+++ b/.github/workflows/check_semver_labels.yml
@@ -17,10 +17,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: >
-            [
-              "major",
-              "minor",
-              "patch"
-            ]
+          one_of: major,minor,patch
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The repo uses the label checker to validate its own pull requests, so
this commit updates that check to use the new comma-separated label
inputs.