### PR TITLE
Enable vscode commit signing flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+    "git.enableCommitSigning": true,
+
     "go.useLanguageServer": true,
     "[go]": {
         "editor.tabSize": 8,


### PR DESCRIPTION
All this flag does is to add `-S` when calling git commit[1].  The steps
carried out to get the vscode terminal working with a gpg passphrase
both locally and in a remote container are documented in #91

[1] https://github.com/microsoft/vscode/issues/97300#issuecomment-626647293