### PR TITLE
Accept one line git commit messages

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -15,4 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2.0.0
+        uses: mristin/opinionated-commit-message@v2.1.0
+        with:
+          allow-one-liners: 'true'


### PR DESCRIPTION
Prior to this fix, one line git commit messages would be rejected by the
check.
Fix is to update to the latest version of the checker, which has the fix
for this[1]

Also see this discussion [2]

[1] https://github.com/mristin/opinionated-commit-message#one-liners
[2] https://github.com/mristin/opinionated-commit-message/issues/55