### PR TITLE
Use Hoverfly action to enable https simulations

### DIFF
--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -20,10 +20,7 @@ jobs:
         uses: agilepathway/hoverfly-github-action@main
         with:
           runner_github_workspace_path: ${{ github.workspace }}
-      - name: Add and trust Hoverfly default certificate
-        run: |
-            wget https://raw.githubusercontent.com/SpectoLabs/hoverfly/master/core/cert.pem
-            sudo mv cert.pem /usr/local/share/ca-certificates/hoverfly.crt
-            sudo update-ca-certificates
+      - name: Enable https calls to be simulated by Hoverfly
+        run: install-and-trust-hoverfly-default-cert.sh
       - name: Tests
         run: go test -v .


### PR DESCRIPTION
We now invoke a script in the Hoverfly GitHub Action[1] to install and
trust the Hoverfly default cert.  This simplifies our code as the logic
has moved to the Hoverfly action.

[1] https://github.com/agilepathway/hoverfly-github-action