### PR TITLE
Allow long URLs in commit messages

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2.1.0
+        uses: mristin/opinionated-commit-message@v2.1.2
         with:
           allow-one-liners: 'true'


### PR DESCRIPTION
Updated to the latest version of the commit message checker which
contains [this new feature][1]

[1]: mristin/opinionated-commit-message#59