### PR TITLE
Stop commit message style checks on master

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -8,6 +8,8 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
   push:
+    branches-ignore:
+      - main
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
There is no need to run the commit message checks on master, because
the master branch is protected.  We continue to run the commit message
checks on all feature branches.