### PR TITLE
Run the tests nightly

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,5 +1,9 @@
 ---
-on: [push]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  # Run the tests on every push, and also at 3am every night
+  push:
+  schedule:
+    - cron: '0 3 * * *'  # * is a special character in YAML so you have to quote this string
 name: Tests
 jobs:
   tests:

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -1,5 +1,9 @@
 ---
-on: [push]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  # Run the tests on every push, and also at 3am every night
+  push:
+  schedule:
+    - cron: '0 3 * * *'  # * is a special character in YAML so you have to quote this string
 name: Tests
 jobs:
   tests:


### PR DESCRIPTION
This is to ensure that we continue to have confidence that the
functionality works, and so that we are alerted to any regressions.

Using the [GitHub Actions scheduler functionality][1]

Closes #33

[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events