### PR TITLE
Fix commit message check master branch exclusion

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
   push:
     branches-ignore:
-      - main
+      - master
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
Had inadvertently excluded `main` instead of `master`, in #102.