### PR TITLE
Update GitHub Actions dependencies automatically

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -1,0 +1,15 @@
+# Updating dependencies
+
+## Dependabot
+
+We use [GitHub Dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically) 
+([bought by GitHub in 2019](https://dependabot.com/blog/hello-github/) and now 
+[baked into GitHub](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)) 
+to manage our dependencies.
+
+Whenever possible we let Dependabot update our dependencies automatically (by 
+[automatically creating a PR](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates#about-github-dependabot-pull-requests)
+for us to merge).
+
+Dependabot will 
+[automatically update non-Docker dependencies in our GitHub Actions](https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "patch"
+    reviewers:
+      - "johnboyes"

--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: docker/build-push-action@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/check_semver_labels.yml
+++ b/.github/workflows/check_semver_labels.yml
@@ -15,6 +15,7 @@ jobs:
     name: Check for semantic version label
     runs-on: ubuntu-latest
     steps:
+      # always use the latest version here, can't use Dependabot or we'll be caught in an infinite update loop
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
           one_of: major,minor,patch

--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -30,17 +30,17 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.2
         with:
           go-version: 1.14
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v2.1.1
         with:
           version: latest
           args: release --rm-dist
@@ -52,8 +52,8 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: docker/build-push-action@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,18 +8,14 @@ name: Tests
 jobs:
   tests:
     name: Integration
-    strategy:
-      matrix:
-        go-version: [1.14.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.14.7
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: Tests
         env:
           INPUT_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,8 +9,8 @@ jobs:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: reviewdog/action-golangci-lint@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: reviewdog/action-golangci-lint@v1.11.0
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "-c .golangci.yml"
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: hadolint
-        uses: reviewdog/action-hadolint@v1
+        uses: reviewdog/action-hadolint@v1.6.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -33,9 +33,9 @@ jobs:
     name: runner / yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
       - name: yamllint
-        uses: reviewdog/action-yamllint@v1
+        uses: reviewdog/action-yamllint@v1.1.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -44,9 +44,9 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@v1.4.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -58,8 +58,8 @@ jobs:
     name: runner / misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: reviewdog/action-misspell@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: reviewdog/action-misspell@v1.5.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -68,8 +68,8 @@ jobs:
     name: runner / languagetool
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: reviewdog/action-languagetool@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: reviewdog/action-languagetool@v1.3.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -8,19 +8,17 @@ name: Tests
 jobs:
   tests:
     name: Virtual
-    strategy:
-      matrix:
-        go-version: [1.14.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.14.7
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: Install Hoverfly
+        # do not specify a specific semver version or we will have an infinite circular dependency loop,
+        # between the hoverfly-github-action and this label-checker
         uses: agilepathway/hoverfly-github-action@main
         with:
           runner_github_workspace_path: ${{ github.workspace }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,8 @@ Run the tests:
 The tests are [table driven](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests), which is an important concept to know when amending them.
 
 The tests also have an integration mode which makes calls to real external services instead of using Hoverfly to virtualise the service calls.  You do not need to run the tests in integration mode when contributing (they will not pass unless you are a [maintainer](.github/CODEOWNERS) of the project who has the designated GitHub permissions).
+
+
+## Updating dependencies
+
+See the [DEPENDENCIES.md](.github/DEPENDENCIES.md)

--- a/README.md
+++ b/README.md
@@ -135,3 +135,8 @@ The project is [open source](https://opensource.guide/how-to-contribute/) and al
 
 - Speed: the [Docker image](https://hub.docker.com/repository/docker/agilepathway/pull-request-label-checker)
   used for the checks is only 2.7 MB, so the checks are blazingly fast (c. 3 seconds)
+
+
+## Updating dependencies
+
+See the [DEPENDENCIES.md](.github/DEPENDENCIES.md)


### PR DESCRIPTION
Use pinned versions in GitHub Actions we consume, tohelp ensure that our
builds are idempotent and reproducible.

Using [Dependabot][1] to keep these pinned versions up to date.

[1]: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot