### PR TITLE
Notify us of non-automatic version updates

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -13,3 +13,18 @@ for us to merge).
 
 Dependabot will 
 [automatically update non-Docker dependencies in our GitHub Actions](https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/).
+
+
+### Workaround for other dependencies
+
+For our other dependencies which cannot be updated automatically by Dependabot, we employ a bit of a hack.  
+We have a [`dependabot_hack.yml`](workflows/dependabot_hack.yml) GitHub Action which triggers a Dependabot PR when these other dependencies have a new version to update to.  This GitHub Action is set to never actually run; it exists just so that Dependabot can do its thing.  The `dependabot_hack.yml` documents where in our codebase that we then need to **update to the new version manually** (we then **add this manual update as another commit to the PR that Dependabot creates**).  NB we are able to use this hack to **manage _any_ dependency that uses 
+[GitHub releases](https://docs.github.com/en/github/administering-a-repository/about-releases)** - we are not limited to just dependencies which are themselves GitHub Actions (this is because Dependabot doesn't care
+whether the dependencies are valid GitHub Actions, it just parses the file and updates any versions that are
+managed through GitHub releases).
+
+We could in theory automate this entirely (by e.g. having a GitHub Action that is triggered by Dependabot PRs,
+which updates the version in the requisite files and then adds the change in a new commit to the Dependabot PR),
+but that would be overkill for now.
+
+Eventually as Dependabot adds more features we may be able to remove this workaround.

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -20,3 +20,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.1.2
         with:
           allow-one-liners: 'true'
+          additional-verbs: 'notify'

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -1,0 +1,21 @@
+---
+# See ../DEPENDENCIES.md#workaround-for-other-dependencies
+name: Dependabot hack
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - never-trigger-this-dependabot-hack-workflow
+
+jobs:
+
+  dependabot_hack:
+    name: Ensure dependabot version checks
+    runs-on: ubuntu-20.04
+    steps:
+
+      # update the version in `github_tag_and_release.yml` manually, too
+      - uses: golang/go@go1.14.7
+
+      # update the variant version in the devcontainer.json manually, too
+      # (see ../DEPENDENCIES.md#devcontainer-base-image-version for more info )
+      - uses: microsoft/vscode-dev-containers@v0.134.0


### PR DESCRIPTION
This is a hack, to get Dependabot to notify us about version updates for
dependencies that it cannot update automatically.

We never want this hack GitHub Action to be triggered (because the
Dependabot doesn't need the action to be triggered in order to carry out
it's version updating), so we have set it to only ever trigger on a
branch name which we will never have.

The PR that Dependabot creates will only have the update for this
`dependabot_hack` file, so we'll have to then manually update the
version wherever it is specified too.  We should do this in the same
PR that Dependabot has created.

[1]: https://dependabot.com/github-actions/
[2]: https://github.com/agilepathway/label-checker