### PR TITLE
Exclude Dependabot commits from message checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-commit-message-style:
+    if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/github_actions/') == false)
     name: Check commit message style
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Commits which are automatically generated by Dependabot typically have
a body line length of [more than the 72 character limit][1] which our
check requires.

[1]: https://github.com/dependabot/feedback/issues/165#issuecomment-544498501