### PR TITLE
Pin Go dependencies in devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,13 +35,13 @@ RUN apt-get update \
         github.com/mdempsky/gocode@latest \
         github.com/sqs/goreturns@latest \
         # gopkgs is still needed even with gopls: https://github.com/microsoft/vscode-go/issues/3050#issuecomment-592263369
-        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
-        github.com/ramya-rao-a/go-outline@latest  \
-        github.com/acroca/go-symbols@latest  \
-        github.com/rogpeppe/godef@latest  \
-        github.com/fatih/gomodifytags@latest  \
-        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
-        github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0 \
+        github.com/uudashr/gopkgs/v2/cmd/gopkgs@v2.1.2  \
+        github.com/ramya-rao-a/go-outline@1.0.0  \
+        github.com/acroca/go-symbols@v0.1.1  \
+        github.com/rogpeppe/godef@v1.1.2  \
+        github.com/fatih/gomodifytags@v1.6.0  \
+        github.com/go-delve/delve/cmd/dlv@v1.5.0 2>&1 \
+        github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0 \
     #
     # Build gocode-gomod
     && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -16,6 +16,12 @@ jobs:
       # update the version in `github_tag_and_release.yml` manually, too
       - uses: golang/go@go1.14.7
 
-      # update the variant version in the devcontainer.json manually, too
-      # (see ../DEPENDENCIES.md#devcontainer-base-image-version for more info )
-      - uses: microsoft/vscode-dev-containers@v0.134.0
+      # update the versions in the devcontainer Dockerfile manually, too
+      - uses: uudashr/gopkgs@v2.1.2
+      - uses: ramya-rao-a/go-outline@1.0.0
+      - uses: acroca/go-symbols@v0.1.1
+      - uses: rogpeppe/godef@v1.1.2
+      - uses: fatih/gomodifytags@v1.6.0
+      - uses: go-delve/delve@v1.5.0
+      - uses: golangci/golangci-lint@v1.30.0
+      - uses: SpectoLabs/hoverfly@v1.3.0


### PR DESCRIPTION
This is to help ensure that our builds are reproducible.

Also set the dependencies to trigger a PR via Dependabot, which will be
our cue to manually update the Dockerfile with the new version.