### PR TITLE
Pin Dockerfile apt-get dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,20 +17,26 @@ ARG USER_GID=$USER_UID
 # hadolint ignore=DL3003,DL3008,DL4006
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils=1.8.2.1 dialog=1.3-20190211-1 2>&1 \
     # Need zip and unzip for the Hoverfly installation
-    && apt-get -y install --no-install-recommends zip unzip \
+    && apt-get -y install --no-install-recommends zip=3.0-11+b1 unzip=6.0-23+deb10u1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install --no-install-recommends git openssh-client less iproute2 procps lsb-release \
+    && apt-get -y install --no-install-recommends \
+        git=1:2.20.1-2+deb10u3 \
+        openssh-client=1:7.9p1-10+deb10u2 \
+        less=487-0.1+b1 \
+        iproute2=4.20.0-2 \
+        procps=2:3.3.15-2 \
+        lsb-release=10.2019051400 \
     # Install Zsh
-    && apt-get -y install --no-install-recommends zsh \
+    && apt-get -y install --no-install-recommends zsh=5.7.1-1 \
     && wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
     #
     # Build Go tools w/module support
     && mkdir -p /tmp/gotools \
     && cd /tmp/gotools \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@v0.4.4 2>&1 \
     && GOPATH=/tmp/gotools GO111MODULE=on go get -v \
         github.com/mdempsky/gocode@latest \
         github.com/sqs/goreturns@latest \
@@ -55,7 +61,7 @@ RUN apt-get update \
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     # [Optional] Add sudo support
-    && apt-get install -y --no-install-recommends sudo \
+    && apt-get install -y --no-install-recommends sudo=1.8.27-1+deb10u2 \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #

--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -30,6 +30,22 @@ but that would be overkill for now.
 Eventually as Dependabot adds more features we may be able to remove this workaround.
 
 
+## Dockerfile dependencies
+
+We have [pinned the linux dependencies in the devcontainer Dockerfile](https://github.com/agilepathway/hoverfly-github-action/pull/112/files), but there is no mechanism to automatically update them, currently.  It looks like [it's on Dependabot's roadmap](https://github.com/dependabot/dependabot-core/issues/2129#issuecomment-511552345), so we have [an issue automatically created every 6 months](https://github.com/agilepathway/hoverfly-github-action/pull/112) to 
+1. update the dependencies manually
+2. see if Dependabot now offer this functionality
+
+
+### Updating the Dockerfile dependencies manually
+
+1. Temporarily unpin the versions (i.e. remove `=<version>` from each package in the Dockerfile)
+2. Execute the Dockerfile (e.g. if it's a remote container Dockerfile build the remote container)
+3. Run `apt-cache policy <package>` for each package, to see the version installed
+4. Pin all the versions, replacing any old versions with new ones
+
+
+
 ## Ubuntu version
 
 [Ubuntu releases annually in April](https://wiki.ubuntu.com/Releases).  In 2020 the GitHub Actions team [supported the new version by mid June](https://github.com/actions/virtual-environments/issues/228#issuecomment-644065532), so we have [an issue automatically created on for 15th July each year](https://github.com/agilepathway/label-checker/pull/111) to prompt us to update. 

--- a/.github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md
@@ -1,0 +1,18 @@
+---
+name: Update dependencies in devcontainer Dockerfile
+about: Stay up to date with Dockerfile dependencies
+title: Update dependencies in devcontainer Dockerfile
+labels: ''
+assignees: ''
+
+---
+
+
+We have [pinned the linux dependencies in the devcontainer Dockerfile](https://github.com/agilepathway/hoverfly-github-action/pull/112/files), but there is no mechanism to automatically update them, currently. It looks like [it's on Dependabot's roadmap](https://github.com/dependabot/dependabot-core/issues/2129#issuecomment-511552345), so this GitHub Issue gets automatically created every 6 months to:
+
+- [ ] update the dependencies manually:
+    1. Temporarily unpin the versions (i.e. remove `=<version>` from each package in the Dockerfile)
+    2. Execute the Dockerfile (e.g. if it's a remote container Dockerfile build the remote container)
+    3. Run `apt-cache policy <package>` for each package, to see the version installed
+    4. Pin all the versions, replacing any old versions with new ones
+- [ ] see if Dependabot now offer this functionality (in which case we can do it automatically, from then on)

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: golang/go@go1.14.7
 
       # update the versions in the devcontainer Dockerfile manually, too
+      - uses: golang/gopls@v0.4.4
       - uses: uudashr/gopkgs@v2.1.2
       - uses: ramya-rao-a/go-outline@1.0.0
       - uses: acroca/go-symbols@v0.1.1

--- a/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
+++ b/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
@@ -1,0 +1,28 @@
+---
+name: Create issue every 6 months to update Dockerfile dependencies
+on:  # yamllint disable-line rule:truthy
+  # Scheduled for 4am on 10th March and 10th Sept every year
+  schedule:
+    - cron: '0 4 10 3,9 *'  # * is a special character in YAML so we have to quote this string
+
+jobs:
+  create_issue:
+    name: Create issue to update Dockerfile dependencies
+    runs-on: ubuntu-20.04
+    steps:
+
+      # Repo code checkout required if `template` is used
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: issue-bot
+        uses: imjohnbo/issue-bot@v2
+        with:
+          assignees: "johnboyes"
+          labels: "dependencies"
+          pinned: false
+          close-previous: false
+          # assignees & labels in the template are overridden by the values specified in this action
+          template: ".github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to pin all versions in our codebase, so that our builds are
reproducible.

We have to update the Dockerfile dependencies manually at the moment,
so this commit also schedules an issue to be created every 6 months to
prompt us to do so.