### PR TITLE
Pin Go version consistently

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,10 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1
+# When we update the base image version (which we do manually, prompted by Dependabot
+# notifying us of a new Go version), make sure our new base images is listed at:
+# https://hub.docker.com/_/golang
+FROM golang:1.14.7-buster
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      # update the version in `github_tag_and_release.yml` manually, too
+      # update the version in these places manually when Dependabot changes it here:
+      # the base image in the devcontainer Dockerfile
+      # github_tag_and_release.yml
+      # integration_test.yml
+      # virtual_test.yml
+      # the go.mod (if it is a major or minor version change e.g. 1.14 to 1.15)
       - uses: golang/go@go1.14.7
 
       # update the versions in the devcontainer Dockerfile manually, too


### PR DESCRIPTION
We want to have a consistent pinned version of Go so that our builds
are reproducible.

Also documented where in our code we need to update the Go version
manually (after Dependabot has notified us of a new Go version to update
to).