### PR TITLE
Pin base image in Dockerfile more specifically

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -14,11 +14,12 @@ jobs:
     steps:
 
       # update the version in these places manually when Dependabot changes it here:
-      # the base image in the devcontainer Dockerfile
-      # github_tag_and_release.yml
-      # integration_test.yml
-      # virtual_test.yml
-      # the go.mod (if it is a major or minor version change e.g. 1.14 to 1.15)
+      # 1. the base image in the Dockerfile
+      # 2. the base image in the devcontainer Dockerfile
+      # 3. github_tag_and_release.yml
+      # 4. integration_test.yml
+      # 5. virtual_test.yml
+      # 6. the go.mod (if it is a major or minor version change e.g. 1.14 to 1.15)
       - uses: golang/go@go1.14.7
 
       # update the versions in the devcontainer Dockerfile manually, too

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.14.7 AS builder
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
We want to pin all of our versions in our codebase as specifically as we
can, to make our builds reproducible.

Also documented that the version should be updated when we update our Go
version across the board.