### PR TITLE
Fix bug which caused all checks to always run

### DIFF
--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -106,7 +106,7 @@ func (a *Action) anyRequired() []string {
 
 func (a *Action) getLabelsFromEnvVar(envVar string) []string {
 	specifiedLabels, present := os.LookupEnv(envVar)
-	if present {
+	if present && (len(strings.TrimSpace(specifiedLabels)) > 0) {
 		return strings.Split(specifiedLabels, ",")
 	}
 

--- a/label_checker_test.go
+++ b/label_checker_test.go
@@ -136,6 +136,10 @@ func TestMain(m *testing.M) {
 	os.Setenv(EnvGitHubRepository, GitHubTestRepo)       //nolint
 	os.Setenv(EnvGitHubEventPath, gitHubEventFullPath()) //nolint
 	os.Setenv(MagefileVerbose, "1")                      //nolint
+	os.Setenv(EnvRequireOneOf, " ")                      //nolint
+	os.Setenv(EnvRequireNoneOf, " ")                     //nolint
+	os.Setenv(EnvRequireAllOf, " ")                      //nolint
+	os.Setenv(EnvRequireAnyOf, " ")                      //nolint
 	setupVirtualServicesIfNotInIntegrationMode()
 	os.Exit(testMainWrapper(m))
 }


### PR DESCRIPTION
This is an important bug fix, as prior to this commit all four label
checks (`one_of`, `none_of`, `all_of`, `any_of`) were always running,
even when not all of the checks were specified to run in the user's
GitHub Actions yaml file.  This in turn was causing unexpected results
when running the Action, e.g. it could cause the pull request validation
to fail when it should pass, and vice versa.

The bug was caused by the code expecting the check values by default
not to be set at all, whereas in reality they default to an empty
string.