### PR TITLE
Enable required status checks on forked PRs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,6 +1,12 @@
 ---
 name: reviewdog
 on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   push:
 
 jobs:

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -1,6 +1,12 @@
 ---
 on:  # yamllint disable-line rule:truthy
-  # Run the tests on every push, and also at 3am every night
+  # Run the tests on every push and pull request, and also at 3am every night
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   push:
   schedule:
     - cron: '0 3 * * *'  # * is a special character in YAML so you have to quote this string


### PR DESCRIPTION
Prior to this commit the [status checks][1] that we need to run on pull
requests were only set to run on pushes.  This meant that they were not
being run when a contributor submitted a PR from a fork.  To fix this
we now run the required status check workflows explicitly on pull
requests as well as pushes.

[1]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks