### PR TITLE
Update and Remove old/deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - godox
     - gomnd
@@ -36,14 +36,12 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
-    - maligned
     - misspell
     - prealloc
     - nakedret
     - rowserrcheck
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck


### PR DESCRIPTION
Prior to this commit, running the linters resulted in:
```
WARN [runner] 
The linter 'golint' is deprecated (since v1.41.0) due to: 
The repository of the linter has been archived by the owner.  
Replaced by revive.

WARN [runner]
The linter 'interfacer' is deprecated (since v1.38.0) due to:
The repository of the linter has been archived by the owner.  


WARN [runner] 
The linter 'maligned' is deprecated (since v1.38.0) due to:
The repository of the linter has been archived by the owner.  
Replaced by govet 'fieldalignment'. 

WARN [runner] 
The linter 'scopelint' is deprecated (since v1.39.0) due to:
The repository of the linter has been deprecated by the owner. 
Replaced by exportloopref. 
```

To remedy this I have:
* Removed `interfacer` because it has been
* [determined to be unreliable and make bad suggestions][1]
* Removed `maligned` since it's now a part of `govet`'s 
  `fieldalignment` rule.
* Updated `scopelint` to `exportloopref`
* Updated `golint` to `revive`.

[1]: https://github.com/golangci/golangci-lint/issues/541