### PR TITLE
Fix problem when running tests locally

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /tmp/hoverfly \
     && cd /tmp/hoverfly || exit \
     && export HOVERFLY_PLATFORM=linux_amd64 \
     && export HOVERFLY_PLATFORM=linux_amd64 \
-    && export HOVERFLY_VERSION=v1.3.0 \
+    && export HOVERFLY_VERSION=v1.3.6 \
     && export HOVERFLY_BUNDLE=hoverfly_bundle_$HOVERFLY_PLATFORM \
     && wget -q --show-progress https://github.com/SpectoLabs/hoverfly/releases/download/$HOVERFLY_VERSION/$HOVERFLY_BUNDLE.zip \
     && unzip $HOVERFLY_BUNDLE.zip \


### PR DESCRIPTION
The problem was caused by using an out of date version of Hoverfly which
had an out date certificate (we use Hoverfly for mocking calls to the
Gitlab API when running thetests).  Fixed by bumping the Hoverfly
version.