### PR TITLE
Fix dev environment terminal problem

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,10 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/zsh",
 		"go.gopath": "/go",
 		"workbench.colorTheme": "Default Dark+",
 		"files.autoSave": "afterDelay",
-		"files.autoSaveDelay": 500,
+		"files.autoSaveDelay": 500
 	},
 	
 	// Add the IDs of extensions you want installed when the container is created.
@@ -22,7 +21,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go version",
+	"postCreateCommand": "go version"
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"


### PR DESCRIPTION
The remote container dev environment was configured to use zsh, which
there was a problem with.  This commit removes zsh as the remote
container terminal so that the default bash terminal is used instead.