### PR TITLE
Fix build on forks

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -8,6 +8,8 @@ jobs:
   build_and_push_docker_image:
     name: Build and push image
     runs-on: ubuntu-20.04
+    # Skip running on forks since forks don't have access to secrets
+    if: github.repository == 'agilepathway/label-checker'
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: docker/build-push-action@v1.1.0


### PR DESCRIPTION
The build on forks was failing because the GitHub Action which tests the
building and pushing the of the Docker image requires access to GitHub
Actions secrets, and forks rightly don't have access to them.  So this
commit [excludes forks from running this GitHub Action][1] (they don't
need to run it, as the additional confidence from it is just a nice to
have).

This ideally would have been part of #274, but was missed.

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository