### PR TITLE
Skip integration tests on forks

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,6 +9,9 @@ jobs:
   tests:
     name: Integration
     runs-on: ubuntu-20.04
+    # Skip running on forks since forks don't have access to the agilepathway repo used
+    # in the integration tests
+    if: github.repository == 'agilepathway/label-checker'
     steps:
       - name: Install Go
         uses: actions/setup-go@v2.1.3


### PR DESCRIPTION
The build on forks was failing because the GitHub Action which runs the
integration tests requires a GitHub token with access to an agilepathway
repo, and forks rightly don't have access.  So this commit [excludes
forks from running this GitHub Action][1] (they don't need to run it,
as the additional confidence from it is just a nice to have, as we also
have the tests which run using mocks and which do run fine on forks).

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository