### PR TITLE
Add GitHub Enterprise tests to CI/CD pipelines

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Tests
         env:
           INPUT_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: go test -integration -v .
+        run: |
+          go test -integration -v .
+          go test -integration -enterprise-cloud -v .

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -31,4 +31,7 @@ jobs:
       - name: Enable https calls to be simulated by Hoverfly
         run: install-and-trust-hoverfly-default-cert.sh
       - name: Tests
-        run: go test -v .
+        run: |
+          go test -v .
+          go test -enterprise-cloud -v .
+          go test -enterprise-server -v .


### PR DESCRIPTION
The only reason that the tests were not added as part of the previous
commit (which enabled GitHub Enterprise) was that the previous commit
was a contribution from a fork, and it was not possible for me to amend
the GitHub Actions workflow files on a fork (rightly, for security
reasons).

NB We do not run the integration tests in GitHub Enterprise Server mode
as that would require having a real GitHub Enterprise Server, which
would be expensive in time and money to maintain.  But having them run
as integration tests in GitHub Enterprise Cloud mode gives us pretty
good test coverage.