### PR TITLE
Specify GitHub Enterprise input var in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,13 @@ inputs:
       See this link for an example of how to set this token:
       https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#example-passing-github_token-as-an-input
     required: true
+  github_enterprise_graphql_url:
+    description: >
+      Only provide this if you are using GitHub Enterprise.
+      For GitHub Enterprise Cloud enter `https://api.github.com/graphql` as the value.
+      For Github Enterprise Server enter `http(s)://<hostname>/api/graphql` as the value.
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
When we added support for GitHub Enterprise in the two commits
immediately preceding this one, we forgot to specify the new [GitHub
Actions input parameter][1] in the `action.yml`.  My guess is that
omission should have prevented the new GitHub Enterprise functionality
from working, but strangely when I end to end tested it manually with
a real pull request on a test repo it seemed to work ok.  Either way
this commit adds the input var to `action.yml` as it should be.

[1]: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs