### PR TITLE
Add allow failure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,38 @@ You can have as many of the checks configured in the same YAML file as you like.
             repo_token: ${{ secrets.GITHUB_TOKEN }}
   ```
 
+
+## Allow failure mode
+
+You can set the label checker to not fail the build, even when a label check succeeds, and then use an
+[`if` condition](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif)
+in a subsequent step or job to conditionally do something or not.
+For example: check if a pull request has a `preview` label
+and then only deploy an ephemeral environment if so.
+
+Set the `allow_failure` mode as an input parameter in the 
+[`with` section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith): 
+`allow_failure: true`
+
+Example:
+
+  ```
+  steps:
+    - id: preview_label_check
+      uses: docker://agilepathway/pull-request-label-checker:latest
+      with:
+        all_of: preview
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        allow_failure: true
+    - if: steps.preview_label_check.outputs.label_check == 'success'
+      run: echo deploy to ephemeral environment
+  ```
+
+The label checker always exposes the `label_check` step output variable,
+regardless of whether `allow_failure` is set or not.
+The variable has a value of either `success` or `failure` which can then be queried in subsequent steps,
+as in the above example.
+
 ## GitHub Enterprise
 
 To use this label checker with [GitHub Enterprise](https://github.com/enterprise),

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,15 @@ inputs:
       For Github Enterprise Server enter `http(s)://<hostname>/api/graphql` as the value.
     required: false
     default: ''
+  allow_failure:
+    description: >
+      Set this to `true` if you do not want the build to fail when the label checker fails,
+      e.g. if you want to use an `if` key in a following step or job to determine if that step
+      should skip/fail/succeed based on the output of the label checker step.  (The label
+      checker step always outputs a step output of `success` or `failure`, which can be
+      used for this purpose.)
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
Allow the label checker to not fail the build, even when a label
check succeeds, and then use an [`if` condition][1] in a subsequent step
or job to conditionally do something or not. For example: check if a
pull request has a `preview` label and then only deploy an ephemeral
environment if so.

The `allow_failure` mode is set via an input parameter in the
[`with` section][2]: `allow_failure: true`

Closes #276 

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif
[2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith