### PR TITLE
Fix generation of Dockerfile dependencies issues

### DIFF
--- a/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
+++ b/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
@@ -15,14 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
+      - uses: imjohnbo/extract-issue-template-fields@v1
+        id: extract
+        with:
+          path: ".github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md"
+
       - name: issue-bot
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "johnboyes"
           labels: "dependencies"
+          title: ${{ steps.extract.outputs.title }}
+          body: ${{ steps.extract.outputs.body }}
           pinned: false
           close-previous: false
-          # assignees & labels in the template are overridden by the values specified in this action
-          template: ".github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The issue generation had been [failing][1] since updating to the `v3`
major version of the [issue bot generator][2].  This commit fixes things
by also using the [separate template action][3] as required from `v3`
onwards.

[1]: https://github.com/agilepathway/label-checker/runs/8282280912?check_suite_focus=true
[2]: https://github.com/imjohnbo/issue-bot/releases/tag/v3.0.0
[3]: https://github.com/imjohnbo/extract-issue-template-fields