### PR TITLE
Update Ubuntu on GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -7,7 +7,7 @@ jobs:
 
   build_and_push_docker_image:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Skip running on forks since forks don't have access to secrets
     if: github.repository == 'agilepathway/label-checker'
     steps:

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -18,7 +18,7 @@ jobs:
       (contains(github.head_ref, 'dependabot/go_modules/') == false) &&
       (contains(github.head_ref, 'dependabot/github_actions/') == false)
     name: Check commit message style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check
         uses: mristin/opinionated-commit-message@v2.3.2

--- a/.github/workflows/check_semver_labels.yml
+++ b/.github/workflows/check_semver_labels.yml
@@ -13,7 +13,7 @@ jobs:
 
   check_semver_label:
     name: Check for semantic version label
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # always use the latest version here, can't use Dependabot or we'll be caught in an infinite update loop
       - uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -10,7 +10,7 @@ jobs:
 
   dependabot_hack:
     name: Ensure dependabot version checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       # update the version in these places manually when Dependabot changes it here:

--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -10,7 +10,7 @@ jobs:
 
   tag:
     name: Tag semantic version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -26,7 +26,7 @@ jobs:
   release:
     needs: tag
     name: Create GitHub Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout
@@ -50,7 +50,7 @@ jobs:
   build_and_push_docker_image:
     needs: tag
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: docker/build-push-action@v1.1.0

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,7 +8,7 @@ name: Tests
 jobs:
   tests:
     name: Integration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Skip running on forks since forks don't have access to the agilepathway repo used
     # in the integration tests
     if: github.repository == 'agilepathway/label-checker'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
 
   golangci-lint:
     name: runner / golangci-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: reviewdog/action-golangci-lint@v1.24
@@ -25,7 +25,7 @@ jobs:
 
   hadolint:
     name: runner / hadolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -37,7 +37,7 @@ jobs:
 
   yamllint:
     name: runner / yamllint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - name: yamllint
@@ -48,7 +48,7 @@ jobs:
 
   shellcheck:
     name: runner / shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - name: shellcheck
@@ -62,7 +62,7 @@ jobs:
 
   misspell:
     name: runner / misspell
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: reviewdog/action-misspell@v1.12.2
@@ -73,7 +73,7 @@ jobs:
 
   languagetool:
     name: runner / languagetool
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: reviewdog/action-languagetool@v1.6

--- a/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
+++ b/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   create_issue:
     name: Create issue to update Dockerfile dependencies
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       # Repo code checkout required if `template` is used

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -14,7 +14,7 @@ name: Tests
 jobs:
   tests:
     name: Virtual
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v2.1.3


### PR DESCRIPTION
GitHub Actions make the latest [Ubuntu LTS version][1] available every 2
years. They made the [22.04 version available in August 2022], so this
commit updates our GitHub Action workflows to use it.

[1]: https://wiki.ubuntu.com/Releases
[2]: https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/