### PR TITLE
Omit Docker test run if Dependabot

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -8,11 +8,15 @@ jobs:
   build_and_push_docker_image:
     name: Build and push image
     runs-on: ubuntu-22.04
-    # Skip running on forks since forks don't have access to secrets
-    if: github.repository == 'agilepathway/label-checker'
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: docker/build-push-action@v1.1.0
+      - name: Build and push Docker image
+        # Skip running on forks or Dependabot since neither has access to secrets
+        if: |
+          (github.repository == 'agilepathway/label-checker') &&
+          (github.actor!= 'dependabot[bot]') &&
+          (contains(github.head_ref, 'dependabot/github_actions/') == false)
+        uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Dependabot doesn't have write access, so it can't do the Docker build and deploy.  This commit ensures that it doesn't try to anymore.