### PR TITLE
Add end-to-end tests

### DIFF
--- a/.github/workflows/end_to_end_test.yml
+++ b/.github/workflows/end_to_end_test.yml
@@ -1,0 +1,23 @@
+---
+name: End-to-end tests
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+
+  check_semver_label:
+    name: end-to-end test one_of
+    runs-on: ubuntu-latest
+    # Run the workflow using the label checker code in the branch for the current PR
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          one_of: major,minor,patch
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This first end-to-end test runs on every pull request, invoking the label checker's `one_of` functionality.  [End-to-end testing][1] gives us greater coverage than the integration tests, as it runs the full label checker. We will add further end-to-end tests later too, to expand the coverage.

[1]: https://circleci.com/blog/what-is-end-to-end-testing/