### PR TITLE
Test allow failure and outputs functionality

### DIFF
--- a/.github/workflows/end_to_end_test.yml
+++ b/.github/workflows/end_to_end_test.yml
@@ -56,3 +56,30 @@ jobs:
           none_of: missing
           any_of: major,minor,patch
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+  end_to_end_test_allow_failure:
+    name: end-to-end test allow failure
+    runs-on: ubuntu-latest
+    # Run the workflow using the label checker code in the branch for the current PR
+    steps:
+      - uses: actions/checkout@v3
+      - id: success_scenario
+        uses: ./
+        with:
+          one_of: major,minor,patch
+          allow_failure: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - id: failure_scenario
+        uses: ./
+        with:
+          one_of: missing
+          allow_failure: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.success_scenario.outputs.label_check != 'success'
+        run: |
+          echo "Allow failure success scenario failed, exiting"
+          exit 1
+      - if: steps.failure_scenario.outputs.label_check != 'failure'
+        run: |
+          echo "Allow failure failure scenario failed, exiting"
+          exit 1


### PR DESCRIPTION
This is achieved through an end-to-end test, which gives great test coverage.  It is particularly important that we now have end-to-end tests for the [`allow failure`][1] and [outputs][2] functionality as we [recently broke the label checker][3] by releasing a bug in this area (we had to release another version immediately which reverted the change).

[1]: https://github.com/agilepathway/label-checker#allow-failure-mode
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
[3]: https://github.com/agilepathway/label-checker/commit/4b2dfdc45359309dc40aaca10c1096a8455112e0