### PR TITLE
Update deprecated set-output GitHub Action command

### DIFF
--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -47,13 +47,13 @@ func (a *Action) CheckLabels() error {
 		return a.handleFailure()
 	}
 
-	fmt.Println(a.resultStepOutput("success"))
+	a.outputResult("success")
 
 	return nil
 }
 
 func (a *Action) handleFailure() error {
-	fmt.Println(a.resultStepOutput("failure"))
+	a.outputResult("failure")
 	err := errors.New(a.trimTrailingNewLine(a.failMsg))
 
 	if a.allowFailure() {
@@ -105,8 +105,17 @@ func (a *Action) pullRequestNumber() int {
 	return event.PullRequestNumber
 }
 
-func (a *Action) resultStepOutput(result string) string {
-	return "::set-output name=label_check::" + result
+func (a *Action) outputResult(result string) {
+	label_check_output := fmt.Sprintf("label_check=%s", result)
+	gitHubOutputFileName := filepath.Clean(os.Getenv("GITHUB_OUTPUT"))
+	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0644)
+	panic.IfError(err)
+	_, err = githubOutputFile.WriteString(label_check_output)
+	if err != nil {
+		githubOutputFile.Close()
+		panic.IfError(err)
+	}
+	githubOutputFile.Close()
 }
 
 func (a *Action) token() string {


### PR DESCRIPTION
As per the [GitHub blog article][1] about this.

Also deleted the integration tests relating to the [allow failure][2]
mode, as the recently added end-to-end tests offer much better test
coverage (the integration tests failed to catch our recent bug there,
whereas the end-to-end tests would have caught it).  So there was no
benefit in refactoring those integration tests as part of this commit,
better to delete them.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[2]: https://github.com/agilepathway/label-checker#allow-failure-mode