### PR TITLE
Remove dependency on Mage

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -23,5 +23,5 @@ jobs:
         env:
           INPUT_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go test -integration -v .
-          go test -integration -enterprise-cloud -v .
+          go test ./... -integration -v
+          go test ./... -integration -enterprise-cloud -v

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -32,6 +32,6 @@ jobs:
         run: install-and-trust-hoverfly-default-cert.sh
       - name: Tests
         run: |
-          go test -v .
-          go test -enterprise-cloud -v .
-          go test -enterprise-server -v .
+          go test ./... -v
+          go test ./... -enterprise-cloud -v
+          go test ./... -enterprise-server -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,6 @@ Firstly thanks for thinking of contributing - the project is [open source](https
   * [Tools and technologies](#tools-and-technologies)
     * [GitHub Actions](#github-actions)
     * [Go](#go)
-    * [Mage](#mage)
-
 [Running the tests](#running-the-tests)
 
 ## How to report a bug or suggest a new feature
@@ -72,27 +70,23 @@ Some reasons we chose [Go](https://golang.org/):
   * [ease of deployment](https://hub.packtpub.com/cloud-native-go-programming/)
   * [backwards compatibility](https://yourbasic.org/golang/advantages-over-java-python/#compatibility)
 
-#### Mage
-
-The application is built using [Mage](https://magefile.org/), which is the Go equivalent of [Make](https://www.gnu.org/software/make/).
-
 ## Running the tests
 
 As [above](#dependencies), you need [Hoverfly](https://hoverfly.readthedocs.io) to run the tests.
 
 Run the tests:
 
-`go test -v .`
+`go test ./... -v`
 
 Running the tests in GitHub Enterprise Cloud mode (verifying that the label checker 
 works properly on [GitHub Enterprise Cloud](https://docs.github.com/en/get-started/onboarding/getting-started-with-github-enterprise-cloud)):
 
-`go test -enterprise-cloud -v .`
+`go test ./... -enterprise-cloud -v`
 
 Running the tests in Github Enterprise Server mode (verifying that the label checker 
 works properly on [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server/admin/overview/about-github-enterprise-server)):
 
-`go test -enterprise-server -v .`
+`go test ./... -enterprise-server -v`
 
 The tests are [table driven](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests), which is an important concept to know when amending them.
 
@@ -100,11 +94,11 @@ The tests also have an integration mode which makes calls to real external servi
 
 If you are a maintainer, and you want to run the integration tests locally, you will need to set the `INPUT_REPO_TOKEN` environment variable, e.g. if using a VS Code Codespace you can run: 
 
-`INPUT_REPO_TOKEN=$GITHUB_TOKEN go test -integration -v .`
+`INPUT_REPO_TOKEN=$GITHUB_TOKEN go test ./... -integration -v`
 
 You can also run the integration tests locally in GitHub Enterprise Cloud mode:
 
-`INPUT_REPO_TOKEN=$GITHUB_TOKEN go test -integration -enterprise-cloud -v .`
+`INPUT_REPO_TOKEN=$GITHUB_TOKEN go test ./... -integration -enterprise-cloud -v`
 
 (we can't run the integration tests in GitHub Enterprise Server mode as that would require having
 a real GitHub Enterprise Server, which would be expensive in time and money to maintain)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.16.6-buster AS builder
 WORKDIR /src
 COPY . .
 
-RUN scripts/install-mage.sh \
-    && CGO_ENABLED=0 GOFLAGS=-ldflags="-w" mage -compile /bin/check-labels -goos linux -goarch amd64 \
+RUN CGO_ENABLED=0 GOFLAGS=-ldflags="-w" GOOS=linux GOARCH=amd64 go build -o /bin/check-labels label_checker.go \
     # Strip any symbols - this is not a library
     && strip /bin/check-labels \
     # Compress the compiled action using UPX (https://upx.github.io/) 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 )](https://github.com/agilepathway/label-checker/releases)
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?maxAge=43200)](LICENSE)
-[![Built with Mage](https://magefile.org/badge.svg)](https://magefile.org)
 [![Go Report Card](https://goreportcard.com/badge/github.com/agilepathway/label-checker)](https://goreportcard.com/report/github.com/agilepathway/label-checker)
 [![Go version](https://img.shields.io/github/go-mod/go-version/agilepathway/label-checker)](https://golang.org/)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ module github.com/agilepathway/label-checker
 go 1.16
 
 require (
-	github.com/magefile/mage v1.13.0
 	github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
-github.com/magefile/mage v1.13.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd h1:EwtC+kDj8s9OKiaStPZtTv3neldOyr98AXIxvmn3Gss=
 github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f h1:tygelZueB1EtXkPI6mQ4o9DQ0+FKW41hTbunoXZCTqk=

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -1,4 +1,4 @@
-package test
+package github
 
 import (
 	"bytes"
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/agilepathway/label-checker/internal/error/panic"
-	"github.com/magefile/mage/mage"
 )
 
 //nolint: gochecknoglobals
@@ -51,10 +50,9 @@ const (
 	OneLabelPR                     = 2 // https://github.com/agilepathway/test-label-checker-consumer/pull/2
 	TwoLabelsPR                    = 3 // https://github.com/agilepathway/test-label-checker-consumer/pull/3
 	ThreeLabelsPR                  = 4 // https://github.com/agilepathway/test-label-checker-consumer/pull/4
-	GitHubEventJSONDir             = "testdata/temp"
+	GitHubEventJSONDir             = "../../testdata/temp"
 	GitHubEventJSONFilename        = "github_event.json"
 	GitHubOutputFilename           = "github_output"
-	MagefileVerbose                = "MAGEFILE_VERBOSE"
 	HoverflyProxyAddress           = "127.0.0.1:8500"
 	NeedNoneGotNone                = "Label check successful: required none of major, minor, patch, and found 0.\n"
 	NeedNoneGotOne                 = "Label check failed: required none of major, minor, patch, but found 1: minor\n"
@@ -84,8 +82,8 @@ func TestLabelChecks(t *testing.T) {
 		expectedStdout string
 		expectedStderr string
 	}{
-		"Need none,                  got none": {NoLabelsPR, checkNone, NeedNoneGotNone, ""},
-		"Need none,                  got one":  {OneLabelPR, checkNone, "", NeedNoneGotOne},
+		"Need none,                  got none":  {NoLabelsPR, checkNone, NeedNoneGotNone, ""},
+		"Need none,                  got one":   {OneLabelPR, checkNone, "", NeedNoneGotOne},
 		"Need none,                  got two":   {TwoLabelsPR, checkNone, "", NeedNoneGotTwo},
 		"Need one,                   got none":  {NoLabelsPR, checkOne, "", NeedOneGotNone},
 		"Need one,                   got one":   {OneLabelPR, checkOne, NeedOneGotOne, ""},
@@ -121,7 +119,7 @@ func TestLabelChecks(t *testing.T) {
 			setPullRequestNumber(tc.prNumber)
 			tc.specifyChecks()
 
-			exitCode, stderr, stdout := checkLabels()
+			exitCode, stdout, stderr := checkLabels()
 
 			if (len(tc.expectedStderr) > 0) && (exitCode == 0) {
 				t.Fatalf("got exit code %v, err: %s", exitCode, stderr)
@@ -154,7 +152,6 @@ func TestMain(m *testing.M) {
 	os.Setenv(EnvGitHubRepository, GitHubTestRepo)       //nolint
 	os.Setenv(EnvGitHubEventPath, gitHubEventFullPath()) //nolint
 	os.Setenv(EnvGitHubOutput, gitHubOutputFullPath())   //nolint
-	os.Setenv(MagefileVerbose, "1")                      //nolint
 	os.Setenv(EnvRequireOneOf, " ")                      //nolint
 	os.Setenv(EnvRequireNoneOf, " ")                     //nolint
 	os.Setenv(EnvRequireAllOf, " ")                      //nolint
@@ -170,7 +167,6 @@ func testMainWrapper(m *testing.M) int {
 		os.RemoveAll(GitHubEventJSONDir)
 		os.Unsetenv(EnvGitHubRepository)
 		os.Unsetenv(EnvGitHubEventPath)
-		os.Unsetenv(MagefileVerbose)
 		os.Unsetenv(EnvGitHubEnterprise)
 		os.Unsetenv(EnvAllowFailure)
 		teardownVirtualServicesIfNotInIntegrationMode()
@@ -217,9 +213,9 @@ func startHoverflyInSpyMode() {
 
 func importGitHubSimulations() {
 	if *enterpriseServer {
-		execHoverCtl("import", "./testdata/github_enterprise_server_api.json")
+		execHoverCtl("import", "../../testdata/github_enterprise_server_api.json")
 	} else {
-		execHoverCtl("import", "./testdata/github_api.json")
+		execHoverCtl("import", "../../testdata/github_api.json")
 	}
 }
 
@@ -230,9 +226,8 @@ func stopHoverfly() {
 func checkLabels() (int, *bytes.Buffer, *bytes.Buffer) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	invocation := mage.Invocation{Stderr: stderr, Stdout: stdout}
-
-	return mage.Invoke(invocation), stderr, stdout
+	a := Action{}
+	return a.CheckLabels(stdout, stderr), stdout, stderr
 }
 
 func setPullRequestNumber(prNumber int) {

--- a/label_checker.go
+++ b/label_checker.go
@@ -1,15 +1,14 @@
-//go:build mage
-// +build mage
-
 //nolint:unused,deadcode,gochecknoglobals
 package main
 
-import "github.com/agilepathway/label-checker/internal/github"
+import (
+	"os"
 
-var Default = PullRequestLabelChecker
+	"github.com/agilepathway/label-checker/internal/github"
+)
 
-// PullRequestLabelChecker checks pull requests for the presence or absence of specified GitHub labels
-func PullRequestLabelChecker() error {
+func main() {
 	a := github.Action{}
-	return a.CheckLabels()
+	exitCode := a.CheckLabels(os.Stdout, os.Stderr)
+	os.Exit(exitCode)
 }

--- a/scripts/install-mage.sh
+++ b/scripts/install-mage.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cd /tmp || exit
-git clone https://github.com/magefile/mage
-cd mage || exit
-go run bootstrap.go


### PR DESCRIPTION
[Mage][1] is a Go build tool which we were using to invoke our label checking Go function and to build our Go binary. We don't need Mage though, as we can simply use the standard Go `main` function and build the binary using the standard `go build` command.

It's always good to remove unneeded dependencies, and also Mage was responsible for setting the beginning of the error output (`Error:`) that is displayed on the console.  By removing Mage we now have control of this.  This paves the way for making the error output a [GitHub Actions  workflow command][2] in a future PR, which will mean the error message is highlighted (which will fix #330).

[1]: https://magefile.org/
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message