### PR TITLE
Add prefix mode

### DIFF
--- a/.github/workflows/end_to_end_test.yml
+++ b/.github/workflows/end_to_end_test.yml
@@ -83,3 +83,15 @@ jobs:
         run: |
           echo "Allow failure failure scenario failed, exiting"
           exit 1
+
+  end_to_end_test_prefix_none_of:
+    name: end-to-end test prefix none_of
+    runs-on: ubuntu-latest
+    # Run the workflow using the label checker code in the branch for the current PR
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          prefix_mode: true
+          none_of: "type:"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -84,4 +84,4 @@ jobs:
             **/*.md
           language: en
           disabled_rules:
-            "GITHUB,DASH_RULE,PUNCTUATION_PARAGRAPH_END"
+            "GITHUB,DASH_RULE,PUNCTUATION_PARAGRAPH_END,MISSING_COMMA_AFTER_INTRODUCTORY_PHRASE"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 - **Speed**: the [Docker image](https://hub.docker.com/repository/docker/agilepathway/pull-request-label-checker)
   used for the checks is only 2.7 MB, so the checks are blazingly fast (c. 3 seconds)
 
+- [Prefix mode](#match-labels-based-on-prefix): check for the presence or absence of labels beginning with a certain prefix
+
 
 ## Using the Label Checker action
 
@@ -94,7 +96,7 @@ You can have as many of the checks configured in the same YAML file as you like.
 
 - Require each PR to have one or more of these labels: `any_of: documentation,enhancement,bug`
 
-- Combine multiple checks:
+#### Combine multiple checks
 
   ```
   with:
@@ -104,7 +106,7 @@ You can have as many of the checks configured in the same YAML file as you like.
     repo_token: ${{ secrets.GITHUB_TOKEN }}
   ```
 
-- Combine multiple checks of the same type:
+#### Combine multiple checks of the same type
 
   ```
   jobs:
@@ -128,6 +130,38 @@ You can have as many of the checks configured in the same YAML file as you like.
             repo_token: ${{ secrets.GITHUB_TOKEN }}
   ```
 
+## Match labels based on prefix
+
+You can set the label checker to check for the presence or absence of labels starting with the given prefix.
+
+This prefix label checking is a powerful feature that allows pull requests to have 
+scoped labels, [similarly to GitLab](https://docs.gitlab.com/ee/user/project/labels.html#scoped-labels).
+
+Set the `prefix_mode` as an input parameter in the 
+[`with` section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith): 
+`prefix_mode: true` (it is an optional parameter as it defaults to false).
+
+Example:
+
+  ```
+  steps:
+    - id: prefix_label_check
+      uses: docker://agilepathway/pull-request-label-checker:latest
+      with:
+        prefix_mode: true
+        one_of: "type:"
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+  ```
+
+  This example will pass if there is exactly one label on the pull request starting with `type:`
+
+You can use any string as the prefix (it doesn't need to contain a `:`, that's just one example)
+
+You can use `one_of`, `any_of`, `none_of` when checking prefixes, but you cannot use `all_of` (as `all_of` does not
+make sense when checking for labels starting with the given prefix).
+
+You can only specify one prefix at a time. For instance you cannot specify `one_of: "type:","visibility/"`.
+You can specify [multiple prefix checks of the same type](#combine-multiple-checks-of-the-same-type) though.
 
 ## Allow failure mode
 
@@ -139,7 +173,7 @@ and then only deploy an ephemeral environment if so.
 
 Set the `allow_failure` mode as an input parameter in the 
 [`with` section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith): 
-`allow_failure: true`
+`allow_failure: true` (it is an optional parameter as it defaults to false).
 
 Example:
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,15 @@ inputs:
       used for this purpose.)
     required: false
     default: ''
+  prefix_mode:
+    description: >
+      Set this to `true` if you want to check for labels based on prefixes instead of checking
+      for the entire label name.  e.g. check for exactly one label with a prefix of "type/" or
+      check there are no labels with a prefix "rework:".  You can specify any string as the
+      prefix to check on, it doesn't need to have a forward slash or colon, these are just
+      examples.
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/agilepathway/label-checker/internal/error/panic"
@@ -42,6 +43,7 @@ const (
 	EnvHTTPSProxy                  = "HTTPS_PROXY"
 	EnvGitHubEnterprise            = "INPUT_GITHUB_ENTERPRISE_GRAPHQL_URL"
 	EnvAllowFailure                = "INPUT_ALLOW_FAILURE"
+	EnvPrefixMode                  = "INPUT_PREFIX_MODE"
 	EnvGitHubOutput                = "GITHUB_OUTPUT"
 	GitHubEnterpriseCloudEndpoint  = "https://api.github.com/graphql"
 	GitHubEnterpriseServerEndpoint = "https://example.com/api/graphql"
@@ -50,6 +52,9 @@ const (
 	OneLabelPR                     = 2 // https://github.com/agilepathway/test-label-checker-consumer/pull/2
 	TwoLabelsPR                    = 3 // https://github.com/agilepathway/test-label-checker-consumer/pull/3
 	ThreeLabelsPR                  = 4 // https://github.com/agilepathway/test-label-checker-consumer/pull/4
+	PrefixOneLabelPR               = 5 // https://github.com/agilepathway/test-label-checker-consumer/pull/5
+	PrefixTwoLabelsPR              = 6 // https://github.com/agilepathway/test-label-checker-consumer/pull/6
+	PrefixThreeLabelsPR            = 7 // https://github.com/agilepathway/test-label-checker-consumer/pull/7
 	GitHubEventJSONDir             = "../../testdata/temp"
 	GitHubEventJSONFilename        = "github_event.json"
 	GitHubOutputFilename           = "github_output"
@@ -70,6 +75,18 @@ const (
 	NeedAnyGotOne                  = "Label check successful: required any of major, minor, patch, and found 1: minor\n"
 	NeedAnyGotTwo                  = "Label check successful: required any of major, minor, patch, and found 2: minor, patch\n"
 	NeedAnyGotThree                = "Label check successful: required any of major, minor, patch, and found 3: major, minor, patch\n"
+	PrefixNeedNoneGotNone          = "Label check successful: required none prefixed with type:, and found 0.\n"
+	PrefixNeedNoneGotOne           = "Label check failed: required none prefixed with type:, but found 1: type:fix\n"
+	PrefixNeedNoneGotTwo           = "Label check failed: required none prefixed with type:, but found 2: type:fix, type:feature\n"
+	PrefixNeedOneGotNone           = "Label check failed: required 1 prefixed with type:, but found 0.\n"
+	PrefixNeedOneGotOne            = "Label check successful: required 1 prefixed with type:, and found 1: type:fix\n"
+	PrefixNeedOneGotTwo            = "Label check failed: required 1 prefixed with type:, but found 2: type:fix, type:feature\n"
+	PrefixNeedAnyGotNone           = "Label check failed: required any prefixed with type:, but found 0.\n"
+	PrefixNeedAnyGotOne            = "Label check successful: required any prefixed with type:, and found 1: type:fix\n"
+	PrefixNeedAnyGotTwo            = "Label check successful: required any prefixed with type:, and found 2: type:fix, type:feature\n"
+	PrefixNeedAnyGotThree          = "Label check successful: required any prefixed with type:, and found 3: type:fix, type:feature, type:documentation\n"
+	PrefixNeedAllError             = "The label checker does not support prefix checking with `all_of`, as that is not a logical combination.\n"
+	PrefixMultiplePrefixesError    = "Currently the label checker only supports checking with one prefix, not multiple.\n"
 )
 
 type specifyChecks func()
@@ -81,32 +98,54 @@ func TestLabelChecks(t *testing.T) {
 		specifyChecks  specifyChecks
 		expectedStdout string
 		expectedStderr string
+		prefixMode     bool
 	}{
-		"Need none,                  got none":  {NoLabelsPR, checkNone, NeedNoneGotNone, ""},
-		"Need none,                  got one":   {OneLabelPR, checkNone, "", NeedNoneGotOne},
-		"Need none,                  got two":   {TwoLabelsPR, checkNone, "", NeedNoneGotTwo},
-		"Need one,                   got none":  {NoLabelsPR, checkOne, "", NeedOneGotNone},
-		"Need one,                   got one":   {OneLabelPR, checkOne, NeedOneGotOne, ""},
-		"Need one,                   got two":   {TwoLabelsPR, checkOne, "", NeedOneGotTwo},
-		"Need all,                   got none":  {NoLabelsPR, checkAll, "", NeedAllGotNone},
-		"Need all,                   got one":   {OneLabelPR, checkAll, "", NeedAllGotOne},
-		"Need all,                   got two":   {TwoLabelsPR, checkAll, "", NeedAllGotTwo},
-		"Need all,                   got all":   {ThreeLabelsPR, checkAll, NeedAllGotAll, ""},
-		"Need any,                   got none":  {NoLabelsPR, checkAny, "", NeedAnyGotNone},
-		"Need any,                   got one":   {OneLabelPR, checkAny, NeedAnyGotOne, ""},
-		"Need any,                   got two":   {TwoLabelsPR, checkAny, NeedAnyGotTwo, ""},
-		"Need any,                   got three": {ThreeLabelsPR, checkAny, NeedAnyGotThree, ""},
-		"Need [none, one],           got none":  {NoLabelsPR, checkNoneAndOne, NeedNoneGotNone, NeedOneGotNone},
-		"Need [none, one],           got one":   {OneLabelPR, checkNoneAndOne, NeedOneGotOne, NeedNoneGotOne},
-		"Need [none, one],           got two":   {TwoLabelsPR, checkNoneAndOne, "", NeedOneGotTwo + NeedNoneGotTwo},
-		"Need [none, one, all],      got none":  {NoLabelsPR, checkNoneAndOneAndAll, NeedNoneGotNone, NeedOneGotNone + NeedAllGotNone},
-		"Need [none, one, all],      got one":   {OneLabelPR, checkNoneAndOneAndAll, NeedOneGotOne, NeedNoneGotOne + NeedAllGotOne},
-		"Need [none, one, all],      got two":   {TwoLabelsPR, checkNoneAndOneAndAll, "", NeedOneGotTwo + NeedNoneGotTwo + NeedAllGotTwo},
-		"Need [none, one, all],      got three": {ThreeLabelsPR, checkNoneAndOneAndAll, NeedAllGotAll, NeedOneGotThree + NeedNoneGotThree},
-		"Need [none, one, all, any], got none":  {NoLabelsPR, checkNoneAndOneAndAllAndAny, NeedNoneGotNone, NeedOneGotNone + NeedAllGotNone + NeedAnyGotNone},
-		"Need [none, one, all, any], got one":   {OneLabelPR, checkNoneAndOneAndAllAndAny, NeedOneGotOne + NeedAnyGotOne, NeedNoneGotOne + NeedAllGotOne},
-		"Need [none, one, all, any], got two":   {TwoLabelsPR, checkNoneAndOneAndAllAndAny, NeedAnyGotTwo, NeedOneGotTwo + NeedNoneGotTwo + NeedAllGotTwo},
-		"Need [none, one, all, any], got three": {ThreeLabelsPR, checkNoneAndOneAndAllAndAny, NeedAllGotAll + NeedAnyGotThree, NeedOneGotThree + NeedNoneGotThree},
+		"Need none,                  got none":  {NoLabelsPR, checkNone, NeedNoneGotNone, "", false},
+		"Need none,                  got one":   {OneLabelPR, checkNone, "", NeedNoneGotOne, false},
+		"Need none,                  got two":   {TwoLabelsPR, checkNone, "", NeedNoneGotTwo, false},
+		"Need one,                   got none":  {NoLabelsPR, checkOne, "", NeedOneGotNone, false},
+		"Need one,                   got one":   {OneLabelPR, checkOne, NeedOneGotOne, "", false},
+		"Need one,                   got two":   {TwoLabelsPR, checkOne, "", NeedOneGotTwo, false},
+		"Need all,                   got none":  {NoLabelsPR, checkAll, "", NeedAllGotNone, false},
+		"Need all,                   got one":   {OneLabelPR, checkAll, "", NeedAllGotOne, false},
+		"Need all,                   got two":   {TwoLabelsPR, checkAll, "", NeedAllGotTwo, false},
+		"Need all,                   got all":   {ThreeLabelsPR, checkAll, NeedAllGotAll, "", false},
+		"Need any,                   got none":  {NoLabelsPR, checkAny, "", NeedAnyGotNone, false},
+		"Need any,                   got one":   {OneLabelPR, checkAny, NeedAnyGotOne, "", false},
+		"Need any,                   got two":   {TwoLabelsPR, checkAny, NeedAnyGotTwo, "", false},
+		"Need any,                   got three": {ThreeLabelsPR, checkAny, NeedAnyGotThree, "", false},
+		"Need [none, one],           got none":  {NoLabelsPR, checkNoneAndOne, NeedNoneGotNone, NeedOneGotNone, false},
+		"Need [none, one],           got one":   {OneLabelPR, checkNoneAndOne, NeedOneGotOne, NeedNoneGotOne, false},
+		"Need [none, one],           got two":   {TwoLabelsPR, checkNoneAndOne, "", NeedOneGotTwo + NeedNoneGotTwo, false},
+		"Need [none, one, all],      got none":  {NoLabelsPR, checkNoneAndOneAndAll, NeedNoneGotNone, NeedOneGotNone + NeedAllGotNone, false},
+		"Need [none, one, all],      got one":   {OneLabelPR, checkNoneAndOneAndAll, NeedOneGotOne, NeedNoneGotOne + NeedAllGotOne, false},
+		"Need [none, one, all],      got two":   {TwoLabelsPR, checkNoneAndOneAndAll, "", NeedOneGotTwo + NeedNoneGotTwo + NeedAllGotTwo, false},
+		"Need [none, one, all],      got three": {ThreeLabelsPR, checkNoneAndOneAndAll, NeedAllGotAll, NeedOneGotThree + NeedNoneGotThree, false},
+		"Need [none, one, all, any], got none":  {NoLabelsPR, checkNoneAndOneAndAllAndAny, NeedNoneGotNone, NeedOneGotNone + NeedAllGotNone + NeedAnyGotNone, false},
+		"Need [none, one, all, any], got one":   {OneLabelPR, checkNoneAndOneAndAllAndAny, NeedOneGotOne + NeedAnyGotOne, NeedNoneGotOne + NeedAllGotOne, false},
+		"Need [none, one, all, any], got two":   {TwoLabelsPR, checkNoneAndOneAndAllAndAny, NeedAnyGotTwo, NeedOneGotTwo + NeedNoneGotTwo + NeedAllGotTwo, false},
+		"Need [none, one, all, any], got three": {ThreeLabelsPR, checkNoneAndOneAndAllAndAny, NeedAllGotAll + NeedAnyGotThree, NeedOneGotThree + NeedNoneGotThree, false},
+
+		// prefix mode tests
+		"(prefix) Need none,          got none":  {NoLabelsPR, prefixCheckNone, PrefixNeedNoneGotNone, "", true},
+		"(prefix) Need none,          got one":   {PrefixOneLabelPR, prefixCheckNone, "", PrefixNeedNoneGotOne, true},
+		"(prefix) Need none,          got two":   {PrefixTwoLabelsPR, prefixCheckNone, "", PrefixNeedNoneGotTwo, true},
+		"(prefix) Need one,           got none":  {NoLabelsPR, prefixCheckOne, "", PrefixNeedOneGotNone, true},
+		"(prefix) Need one,           got one":   {PrefixOneLabelPR, prefixCheckOne, PrefixNeedOneGotOne, "", true},
+		"(prefix) Need one,           got two":   {PrefixTwoLabelsPR, prefixCheckOne, "", PrefixNeedOneGotTwo, true},
+		"(prefix) Need any,           got none":  {NoLabelsPR, prefixCheckAny, "", PrefixNeedAnyGotNone, true},
+		"(prefix) Need any,           got one":   {PrefixOneLabelPR, prefixCheckAny, PrefixNeedAnyGotOne, "", true},
+		"(prefix) Need any,           got two":   {PrefixTwoLabelsPR, prefixCheckAny, PrefixNeedAnyGotTwo, "", true},
+		"(prefix) Need any,           got three": {PrefixThreeLabelsPR, prefixCheckAny, PrefixNeedAnyGotThree, "", true},
+		"(prefix) Need [none, one],   got none":  {NoLabelsPR, prefixCheckNoneAndOne, PrefixNeedNoneGotNone, PrefixNeedOneGotNone, true},
+		"(prefix) Need all,           got none":  {NoLabelsPR, prefixCheckAll, "", PrefixNeedAllError, true},
+		"(prefix) Need all,           got one":   {PrefixOneLabelPR, prefixCheckAll, "", PrefixNeedAllError, true},
+		"(prefix) Need all,           got two":   {PrefixTwoLabelsPR, prefixCheckAll, "", PrefixNeedAllError, true},
+		"(prefix) Need all,           got all":   {PrefixThreeLabelsPR, prefixCheckAll, "", PrefixNeedAllError, true},
+		"(prefix) Need none, multiple prefixes":  {NoLabelsPR, prefixCheckNoneWithMultiplePrefixes, "", PrefixMultiplePrefixesError, true},
+		"(prefix) Need one, multiple prefixes":   {NoLabelsPR, prefixCheckOneWithMultiplePrefixes, "", PrefixMultiplePrefixesError, true},
+		"(prefix) Need any, multiple prefixes":   {NoLabelsPR, prefixCheckAnyWithMultiplePrefixes, "", PrefixMultiplePrefixesError, true},
+		"(prefix) Need all, multiple prefixes":   {NoLabelsPR, prefixCheckAllWithMultiplePrefixes, "", PrefixMultiplePrefixesError, true},
 	}
 	for name, tc := range tests {
 		tc := tc
@@ -117,6 +156,7 @@ func TestLabelChecks(t *testing.T) {
 				tc.expectedStderr = "::error:: " + tc.expectedStderr
 			}
 			setPullRequestNumber(tc.prNumber)
+			setPrefixMode(tc.prefixMode)
 			tc.specifyChecks()
 
 			exitCode, stdout, stderr := checkLabels()
@@ -137,6 +177,7 @@ func TestLabelChecks(t *testing.T) {
 				t.Fatalf("expected %q but got %q", tc.expectedStderr, actual)
 			}
 
+			os.Unsetenv(EnvPrefixMode)    //nolint
 			os.Unsetenv(EnvRequireNoneOf) //nolint
 			os.Unsetenv(EnvRequireOneOf)  //nolint
 			os.Unsetenv(EnvRequireAllOf)  //nolint
@@ -155,6 +196,7 @@ func TestMain(m *testing.M) {
 	os.Setenv(EnvRequireOneOf, " ")                      //nolint
 	os.Setenv(EnvRequireNoneOf, " ")                     //nolint
 	os.Setenv(EnvRequireAllOf, " ")                      //nolint
+	os.Setenv(EnvRequireAnyOf, " ")                      //nolint
 	os.Setenv(EnvRequireAnyOf, " ")                      //nolint
 	setupVirtualServicesIfNotInIntegrationMode()
 	setEnterpriseEndpointIfInEnterpriseMode()
@@ -235,25 +277,66 @@ func setPullRequestNumber(prNumber int) {
 	os.WriteFile(gitHubEventFullPath(), githubEventJSON, os.ModePerm) //nolint
 }
 
+func setPrefixMode(prefixMode bool) {
+	os.Setenv(EnvPrefixMode, strconv.FormatBool(prefixMode)) //nolint
+}
+
 func checkOne() {
 	os.Setenv(EnvRequireOneOf, "major,minor,patch") //nolint
+}
+
+func prefixCheckOne() {
+	os.Setenv(EnvRequireOneOf, "type:") //nolint
 }
 
 func checkNone() {
 	os.Setenv(EnvRequireNoneOf, `major,minor,patch`) //nolint
 }
 
+func prefixCheckNone() {
+	os.Setenv(EnvRequireNoneOf, `type:`) //nolint
+}
+
 func checkAll() {
 	os.Setenv(EnvRequireAllOf, `major,minor,patch`) //nolint
+}
+
+func prefixCheckAll() {
+	os.Setenv(EnvRequireAllOf, `type:`) //nolint
 }
 
 func checkAny() {
 	os.Setenv(EnvRequireAnyOf, `major,minor,patch`) //nolint
 }
 
+func prefixCheckAny() {
+	os.Setenv(EnvRequireAnyOf, `type:`) //nolint
+}
+
 func checkNoneAndOne() {
 	checkNone()
 	checkOne()
+}
+
+func prefixCheckNoneAndOne() {
+	prefixCheckNone()
+	prefixCheckOne()
+}
+
+func prefixCheckNoneWithMultiplePrefixes() {
+	os.Setenv(EnvRequireNoneOf, `type:,visibility/`) //nolint
+}
+
+func prefixCheckOneWithMultiplePrefixes() {
+	os.Setenv(EnvRequireOneOf, `type:,visibility/`) //nolint
+}
+
+func prefixCheckAnyWithMultiplePrefixes() {
+	os.Setenv(EnvRequireAnyOf, `type:,visibility/`) //nolint
+}
+
+func prefixCheckAllWithMultiplePrefixes() {
+	os.Setenv(EnvRequireAllOf, `type:,visibility/`) //nolint
 }
 
 func checkNoneAndOneAndAll() {

--- a/internal/github/pullrequest/labels.go
+++ b/internal/github/pullrequest/labels.go
@@ -13,32 +13,36 @@ type Labels []string
 
 // HasExactlyOneOf indicates whether the labels contain exactly
 // one of the specified labels, along with a report describing the result.
-func (l Labels) HasExactlyOneOf(specified []string) (bool, string) {
-	return l.hasXof(specified, "1")
+func (l Labels) HasExactlyOneOf(specified []string, prefixMode bool) (bool, string) {
+	return l.hasXof(specified, "1", prefixMode)
 }
 
 // HasNoneOf indicates whether the labels contain
 // none of the specified labels, along with a report describing the result.
-func (l Labels) HasNoneOf(specified []string) (bool, string) {
-	return l.hasXof(specified, "none")
+func (l Labels) HasNoneOf(specified []string, prefixMode bool) (bool, string) {
+	return l.hasXof(specified, "none", prefixMode)
 }
 
 // HasAllOf indicates whether the labels contain
 // all of the specified labels, along with a report describing the result.
-func (l Labels) HasAllOf(specified []string) (bool, string) {
-	return l.hasXof(specified, "all")
+func (l Labels) HasAllOf(specified []string, prefixMode bool) (bool, string) {
+	if prefixMode {
+		return false, "The label checker does not support prefix checking with `all_of`, as that is not a logical combination."
+	}
+	return l.hasXof(specified, "all", prefixMode)
 }
 
 // HasAnyOf indicates whether the labels contain
 // any of the specified labels, along with a report describing the result.
-func (l Labels) HasAnyOf(specified []string) (bool, string) {
-	return l.hasXof(specified, "any")
+func (l Labels) HasAnyOf(specified []string, prefixMode bool) (bool, string) {
+	return l.hasXof(specified, "any", prefixMode)
 }
 
 type labelCheck struct {
-	Specified []string
-	Found     []string
-	CheckFor  string
+	Specified  []string
+	Found      []string
+	CheckFor   string
+	PrefixMode bool
 }
 
 func (v labelCheck) IsValid() bool {
@@ -62,7 +66,7 @@ func (v labelCheck) NumberFound() int {
 	return len(v.Found)
 }
 
-func (l Labels) hasXof(specified []string, checkFor string) (bool, string) {
+func (l Labels) hasXof(specified []string, checkFor string, prefixMode bool) (bool, string) {
 	var (
 		labelCheckMsgBuilder strings.Builder
 		foundLabels          []string
@@ -72,19 +76,26 @@ func (l Labels) hasXof(specified []string, checkFor string) (bool, string) {
 		"Label check " +
 		"{{if .IsValid}}successful{{else }}failed{{end}}: " +
 		"required {{.CheckFor}} " +
-		"of {{range $s := .Specified}}{{$s}}, {{end}}" +
+		"{{if .PrefixMode}}prefixed with{{else }}of{{end}} " +
+		"{{range $s := .Specified}}{{$s}}, {{end}}" +
 		"{{if .IsValid}}and{{else }}but{{end}} " +
 		"found {{.NumberFound}}" +
 		"{{if .NumberFound}}: {{else }}.{{end}}" +
 		"{{range $i, $f := .Found}}{{if $i}}, {{end}}{{$f}}{{end}}"))
 
 	for i := 0; i < len(l); i++ {
-		if slice.Contains(specified, l[i]) {
-			foundLabels = append(foundLabels, l[i])
+		if prefixMode {
+			if slice.StartsWithAnyOf(specified, l[i]) {
+				foundLabels = append(foundLabels, l[i])
+			}
+		} else {
+			if slice.Contains(specified, l[i]) {
+				foundLabels = append(foundLabels, l[i])
+			}
 		}
 	}
 
-	check := labelCheck{specified, foundLabels, checkFor}
+	check := labelCheck{specified, foundLabels, checkFor, prefixMode}
 
 	panic.IfError(t.Execute(&labelCheckMsgBuilder, check))
 

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -3,10 +3,24 @@ Package slice provides utility functions for slices
 */
 package slice
 
+import (
+	"strings"
+)
+
 // Contains returns true if the given slice contains the given string
 func Contains(slice []string, val string) bool {
 	for _, item := range slice {
 		if item == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func StartsWithAnyOf(prefixes []string, candidate string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(candidate, prefix) {
 			return true
 		}
 	}

--- a/testdata/github_api.json
+++ b/testdata/github_api.json
@@ -448,6 +448,342 @@
 					},
 					"templated": false
 				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "api.github.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":5}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:37 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"GitHub.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF4F1:106A996:5F040FBE"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4995"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "api.github.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":6}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"},{\"name\":\"type:feature\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:37 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"GitHub.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF4F1:106A996:5F040FBE"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4995"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "api.github.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":7}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"},{\"name\":\"type:feature\"},{\"name\":\"type:documentation\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:37 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"GitHub.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF4F1:106A996:5F040FBE"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4995"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
 			}
 		],
 		"globalActions": {

--- a/testdata/github_enterprise_server_api.json
+++ b/testdata/github_enterprise_server_api.json
@@ -448,6 +448,342 @@
 					},
 					"templated": false
 				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/api/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "example.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":5}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:37 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"example.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF4F1:106A996:5F040FBE"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4995"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/api/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "example.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":6}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"},{\"name\":\"type:feature\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:54 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"example.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF87A:106ADC2:5F040FCF"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4990"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
+			},
+			{
+				"request": {
+					"path": [
+						{
+							"matcher": "exact",
+							"value": "/api/graphql"
+						}
+					],
+					"method": [
+						{
+							"matcher": "exact",
+							"value": "POST"
+						}
+					],
+					"destination": [
+						{
+							"matcher": "exact",
+							"value": "example.com"
+						}
+					],
+					"scheme": [
+						{
+							"matcher": "exact",
+							"value": "https"
+						}
+					],
+					"body": [
+						{
+							"matcher": "json",
+							"value": "{\"query\":\"query($name:String!$owner:String!$pullRequestNumber:Int!){repository(owner: $owner, name: $name){pullRequest(number: $pullRequestNumber){labels(first: 100){nodes{name}}}}}\",\"variables\":{\"name\":\"test-label-checker-consumer\",\"owner\":\"agilepathway\",\"pullRequestNumber\":7}}\n"
+						}
+					]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\"data\":{\"repository\":{\"pullRequest\":{\"labels\":{\"nodes\":[{\"name\":\"type:fix\"},{\"name\":\"type:feature\"},{\"name\":\"type:documentation\"}]}}}}}",
+					"encodedBody": false,
+					"headers": {
+						"Access-Control-Allow-Origin": [
+							"*"
+						],
+						"Access-Control-Expose-Headers": [
+							"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+						],
+						"Cache-Control": [
+							"no-cache"
+						],
+						"Content-Encoding": [
+							"identity"
+						],
+						"Content-Security-Policy": [
+							"default-src 'none'"
+						],
+						"Content-Type": [
+							"application/json; charset=utf-8"
+						],
+						"Date": [
+							"Tue, 07 Jul 2020 06:01:54 GMT"
+						],
+						"Hoverfly": [
+							"Was-Here"
+						],
+						"Referrer-Policy": [
+							"origin-when-cross-origin, strict-origin-when-cross-origin"
+						],
+						"Server": [
+							"example.com"
+						],
+						"Status": [
+							"200 OK"
+						],
+						"Strict-Transport-Security": [
+							"max-age=31536000; includeSubdomains; preload"
+						],
+						"Vary": [
+							"Accept-Encoding, Accept, X-Requested-With",
+							"Accept-Encoding"
+						],
+						"X-Accepted-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Content-Type-Options": [
+							"nosniff"
+						],
+						"X-Frame-Options": [
+							"deny"
+						],
+						"X-Github-Media-Type": [
+							"github.v4; format=json"
+						],
+						"X-Github-Request-Id": [
+							"DD25:5656:CAF87A:106ADC2:5F040FCF"
+						],
+						"X-Oauth-Scopes": [
+							"repo"
+						],
+						"X-Ratelimit-Limit": [
+							"5000"
+						],
+						"X-Ratelimit-Remaining": [
+							"4990"
+						],
+						"X-Ratelimit-Reset": [
+							"1594102919"
+						],
+						"X-Xss-Protection": [
+							"1; mode=block"
+						]
+					},
+					"templated": false
+				}
 			}
 		],
 		"globalActions": {


### PR DESCRIPTION
This is a new feature that checks for the presence or absence of labels
starting with a given prefix.

This prefix label checking is a powerful feature that allows pull
requests to have scoped labels [in a similar way to GitLab][1].

To use, set the `prefix_mode` as an input parameter in the
`with` section: `prefix_mode: true`.
It is an optional parameter as it defaults to false.

Any string can be used as the prefix.

`one_of`, `any_of`, `none_of` can be used when checking prefixes, but
`all_of` cannot (as `all_of` does not make sense when checking for
labels starting with a given prefix).

Only one prefix can be specified at a time. For instance
`one_of: "type:","visibility/"` is not allowed.

Closes https://github.com/agilepathway/label-checker/issues/328

[1]: https://docs.gitlab.com/ee/user/project/labels.html#scoped-labels