### PR TITLE
Pin less specific version of the Delve debugger

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
     && cd /tmp/gotools \
     && GOPATH=/tmp/gotools go get -v golang.org/x/tools/gopls@v0.7.0 2>&1 \
     && GOPATH=/tmp/gotools go get -v \
-        github.com/go-delve/delve/cmd/dlv@v1.7.0 2>&1 \
+        github.com/go-delve/delve/cmd/dlv@v1 2>&1 \
         github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1 \
     #
     # Install Go tools

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: acroca/go-symbols@v0.1.1
       - uses: rogpeppe/godef@v1.1.2
       - uses: fatih/gomodifytags@v1.13.0
-      - uses: go-delve/delve@v1.7.0
+      - uses: go-delve/delve@v1
       - uses: golangci/golangci-lint@v1.41.1
       - uses: SpectoLabs/hoverfly@v1.3.0


### PR DESCRIPTION
To make the application easier to maintain, we will pin just to major versions of [Delve][1] (as minor and patch versions are both always backwards compatible).

[1]: https://github.com/go-delve/delve