### PR TITLE
Pin less specific version of hadolint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,9 +67,9 @@ RUN mkdir -p /tmp/hoverfly \
     && export HOVERFLY_PLATFORM=linux_amd64 \
     && export HOVERFLY_PLATFORM=linux_amd64 \
     && export HOVERFLY_VERSION=v1.3.6 \
-    && export HOVERFLY_BUNDLE=hoverfly_bundle_$HOVERFLY_PLATFORM \
-    && wget -q --show-progress https://github.com/SpectoLabs/hoverfly/releases/download/$HOVERFLY_VERSION/$HOVERFLY_BUNDLE.zip \
-    && unzip $HOVERFLY_BUNDLE.zip \
+    && export "HOVERFLY_BUNDLE=hoverfly_bundle_$HOVERFLY_PLATFORM" \
+    && wget -q --show-progress "https://github.com/SpectoLabs/hoverfly/releases/download/$HOVERFLY_VERSION/$HOVERFLY_BUNDLE.zip" \
+    && unzip "$HOVERFLY_BUNDLE.zip" \
     && mv hoverfly /usr/local/bin/ \
     && mv hoverctl /usr/local/bin/ \
     && chmod +x /usr/local/bin/hoverfly \

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.4
       - name: hadolint
-        uses: reviewdog/action-hadolint@v1.33
+        uses: reviewdog/action-hadolint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check


### PR DESCRIPTION
We use [hadolint][1] for Docker linting. To make the application easier
to maintain we will pin just to major versions of [the reviewdog
hadolint GitHub Action][2] (as minor and patch versions are both always
backwards compatible).

* Fix issues reported by hadolint Dockerfile linter

[1]: https://github.com/hadolint/hadolint
[1]: https://github.com/reviewdog/action-hadolint