### PR TITLE
Use latest Debian version for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@
 # When we update the base image version (which we do manually, prompted by Dependabot
 # notifying us of a new Go version), make sure our new base images is listed at:
 # https://hub.docker.com/_/golang
-FROM golang:1.20.1-buster
+FROM golang:1.20.1-bullseye
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs


### PR DESCRIPTION
Until now we were on Buster, but [Buster has already reached its end of life][1].

[1]: https://wiki.debian.org/DebianReleases