### PR TITLE
Pin less specific version of golangci-lint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
     && cd /tmp/gotools \
     && GOPATH=/tmp/gotools go install golang.org/x/tools/gopls@v0.7.0 2>&1 \
     && GOPATH=/tmp/gotools go install github.com/go-delve/delve/cmd/dlv@v1 2>&1 \
-    && GOPATH=/tmp/gotools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1 2>&1 \
+    && GOPATH=/tmp/gotools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1 2>&1 \
     #
     # Install Go tools
     && mv /tmp/gotools/bin/* /usr/local/bin/ \

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rogpeppe/godef@v1.1.2
       - uses: fatih/gomodifytags@v1.13.0
       - uses: go-delve/delve@v1
-      - uses: golangci/golangci-lint@v1.41.1
+      - uses: golangci/golangci-lint@v1
       - uses: SpectoLabs/hoverfly@v1.3.0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: reviewdog/action-golangci-lint@v1.24
+      - uses: reviewdog/action-golangci-lint@v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "-c .golangci.yml"


### PR DESCRIPTION
To make the application easier to maintain, we will pin just to major versions of [golangci-lint][1] (as minor and patch versions are both always backwards compatible).

[1]: https://golangci-lint.run