### PR TITLE
Pin less specific version of gopls

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
     # Build Go tools
     && mkdir -p /tmp/gotools \
     && cd /tmp/gotools \
-    && GOPATH=/tmp/gotools go install golang.org/x/tools/gopls@v0.7.0 2>&1 \
+    && GOPATH=/tmp/gotools go install golang.org/x/tools/gopls@v0 2>&1 \
     && GOPATH=/tmp/gotools go install github.com/go-delve/delve/cmd/dlv@v1 2>&1 \
     && GOPATH=/tmp/gotools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1 2>&1 \
     #

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: golang/go@go1.20.1
 
       # update the versions in the devcontainer Dockerfile manually, too
-      - uses: golang/tools@gopls/v0.7.0
+      - uses: golang/tools@gopls/v0
       - uses: uudashr/gopkgs@v2.1.2
       - uses: ramya-rao-a/go-outline@1.0.0
       - uses: acroca/go-symbols@v0.1.1


### PR DESCRIPTION
To make the application easier to maintain, we will pin just to major versions of [gopls][1] (the Go [language server][2]) (as minor and patch versions are both always backwards compatible).

[1]: https://github.com/golang/tools/tree/master/gopls
[2]: https://langserver.org/