### PR TITLE
Pin major versions of GitHub Actions dependencies

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: Build and push Docker image
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |

--- a/.github/workflows/check-commit-message-pr.yml
+++ b/.github/workflows/check-commit-message-pr.yml
@@ -17,7 +17,7 @@ jobs:
         if: |
           (github.actor!= 'dependabot[bot]') &&
           (contains(github.head_ref, 'dependabot/github_actions/') == false)
-        uses: mristin/opinionated-commit-message@v3.0.0
+        uses: mristin/opinionated-commit-messagev3.0.0
         with:
           allow-one-liners: 'true'
           # omit PR body as it is not part of our squashed commits

--- a/.github/workflows/check-commit-message-push.yml
+++ b/.github/workflows/check-commit-message-push.yml
@@ -14,7 +14,7 @@ jobs:
         if: |
           (github.actor!= 'dependabot[bot]') &&
           (contains(github.head_ref, 'dependabot/github_actions/') == false)
-        uses: mristin/opinionated-commit-message@v3.0.0
+        uses: mristin/opinionated-commit-messagev3.0.0
         with:
           allow-one-liners: 'true'
           additional-verbs: 'notify, tidy'

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -20,8 +20,7 @@ jobs:
       # 4. integration_test.yml
       # 5. virtual_test.yml
       # 6. the go.mod (if it is a major or minor version change e.g. 1.14 to 1.15)
-      # NB apart from go.mod, always specify the patch level version e.g 1.15.1
-      #    (bear in mind there is no `.0` patch level version though, i.e. use 1.15 not 1.15.0)
+      # NB bear in mind there is no `.0` patch level version, i.e. use 1.15 not 1.15.0
       - uses: golang/go@go1.20.1
 
       # update the versions in the devcontainer Dockerfile manually, too

--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -30,12 +30,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2
         with:
           go-version: 1.20.1
       -
@@ -52,7 +52,7 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,11 +14,11 @@ jobs:
     if: github.repository == 'agilepathway/label-checker'
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2
         with:
           go-version: 1.20.1
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: Tests
         env:
           INPUT_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
     name: runner / golangci-lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - uses: reviewdog/action-golangci-lint@v1
         with:
           github_token: ${{ secrets.github_token }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: hadolint
         uses: reviewdog/action-hadolint@v1
         with:
@@ -39,9 +39,9 @@ jobs:
     name: runner / yamllint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: yamllint
-        uses: reviewdog/action-yamllint@v1.6.1
+        uses: reviewdog/action-yamllint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -50,9 +50,9 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1.15.0
+        uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -64,8 +64,8 @@ jobs:
     name: runner / misspell
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: reviewdog/action-misspell@v1.12.2
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-misspell@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -75,8 +75,8 @@ jobs:
     name: runner / languagetool
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: reviewdog/action-languagetool@v1.9
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-languagetool@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check

--- a/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
+++ b/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
@@ -13,7 +13,7 @@ jobs:
 
       # Repo code checkout required if `template` is used
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
 
       - uses: imjohnbo/extract-issue-template-fields@v1
         id: extract

--- a/.github/workflows/virtual_test.yml
+++ b/.github/workflows/virtual_test.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2
         with:
           go-version: 1.20.1
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: Install Hoverfly
         # do not specify a specific semver version or we will have an infinite circular dependency loop,
         # between the hoverfly-github-action and this label-checker


### PR DESCRIPTION
Prior to this commit we were pinning to patch level dependencies. Just pinning to major versions will make the application easier to maintain - fewer updates.  We have sufficiently high test coverage to feel we can make this change safely.  If it causes a problem in the future (which is unlikely) we can pin specific dependencies at minor or patch level again if needed.

We have left some of the dependencies still pinned to patch versions, for instance the tag and release dependencies, as we need to be very careful with them. We will investigate those dependencies more closely at some time in the future and may pin them just to major versions in a new pull request if we think it's safe enough.