### PR TITLE
Bump Hoverfly version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p /tmp/hoverfly \
     && cd /tmp/hoverfly || exit \
     && export HOVERFLY_PLATFORM=linux_amd64 \
     && export HOVERFLY_PLATFORM=linux_amd64 \
-    && export HOVERFLY_VERSION=v1.3.6 \
+    && export HOVERFLY_VERSION=v1.5.0 \
     && export "HOVERFLY_BUNDLE=hoverfly_bundle_$HOVERFLY_PLATFORM" \
     && wget -q --show-progress "https://github.com/SpectoLabs/hoverfly/releases/download/$HOVERFLY_VERSION/$HOVERFLY_BUNDLE.zip" \
     && unzip "$HOVERFLY_BUNDLE.zip" \


### PR DESCRIPTION
This change should have been in the previous [v1.4.24 release][1], but was accidentally missed.

[1]: https://github.com/agilepathway/label-checker/releases/tag/v1.4.24