### PR TITLE
Use PR number from pull_request object

### DIFF
--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -105,7 +105,9 @@ func (a *Action) repositoryName() string {
 
 func (a *Action) pullRequestNumber() int {
 	event := struct {
-		PullRequestNumber int `json:"number"`
+		PullRequest struct {
+			Number int `json:"number"`
+		} `json:"pull_request"`
 	}{}
 	githubEventJSONFile, err := os.Open(filepath.Clean(os.Getenv("GITHUB_EVENT_PATH")))
 	panic.IfError(err)
@@ -113,7 +115,7 @@ func (a *Action) pullRequestNumber() int {
 	byteValue, _ := ioutil.ReadAll(githubEventJSONFile)
 	panic.IfError(json.Unmarshal(byteValue, &event))
 
-	return event.PullRequestNumber
+	return event.PullRequest.Number
 }
 
 func (a *Action) outputResult(result string) {

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -273,7 +273,7 @@ func checkLabels() (int, *bytes.Buffer, *bytes.Buffer) {
 }
 
 func setPullRequestNumber(prNumber int) {
-	githubEventJSON := []byte(fmt.Sprintf(`{ "number": %d }`, prNumber))
+	githubEventJSON := []byte(fmt.Sprintf(`{ "pull_request": { "number": %d } }`, prNumber))
 	os.WriteFile(gitHubEventFullPath(), githubEventJSON, os.ModePerm) //nolint
 }
 


### PR DESCRIPTION
`pull_request_review` event payload does not contain `number` field. However pull request based events (`pull_request`, `pull_request_review` etc) contain `pull_request` object inside payload and inside this object there is `number` field that could be used.

Fixes #385 

Sorry for ugly code, I'm not GO dev. I've run tests and they were passing on my local.