### PR TITLE
Fix commit message checks

### DIFF
--- a/.github/workflows/check-commit-message-pr.yml
+++ b/.github/workflows/check-commit-message-pr.yml
@@ -17,7 +17,7 @@ jobs:
         if: |
           (github.actor!= 'dependabot[bot]') &&
           (contains(github.head_ref, 'dependabot/github_actions/') == false)
-        uses: mristin/opinionated-commit-messagev3.0.0
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           allow-one-liners: 'true'
           # omit PR body as it is not part of our squashed commits

--- a/.github/workflows/check-commit-message-push.yml
+++ b/.github/workflows/check-commit-message-push.yml
@@ -14,7 +14,7 @@ jobs:
         if: |
           (github.actor!= 'dependabot[bot]') &&
           (contains(github.head_ref, 'dependabot/github_actions/') == false)
-        uses: mristin/opinionated-commit-messagev3.0.0
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           allow-one-liners: 'true'
           additional-verbs: 'notify, tidy'


### PR DESCRIPTION
The `@` had been erroneously removed in the `uses` section of our commit message check GitHub Actions.