### PR TITLE
Revert #386

### DIFF
--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -105,9 +105,7 @@ func (a *Action) repositoryName() string {
 
 func (a *Action) pullRequestNumber() int {
 	event := struct {
-		PullRequest struct {
-			Number int `json:"number"`
-		} `json:"pull_request"`
+		PullRequestNumber int `json:"number"`
 	}{}
 	githubEventJSONFile, err := os.Open(filepath.Clean(os.Getenv("GITHUB_EVENT_PATH")))
 	panic.IfError(err)
@@ -115,7 +113,7 @@ func (a *Action) pullRequestNumber() int {
 	byteValue, _ := ioutil.ReadAll(githubEventJSONFile)
 	panic.IfError(json.Unmarshal(byteValue, &event))
 
-	return event.PullRequest.Number
+	return event.PullRequestNumber
 }
 
 func (a *Action) outputResult(result string) {

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -273,7 +273,7 @@ func checkLabels() (int, *bytes.Buffer, *bytes.Buffer) {
 }
 
 func setPullRequestNumber(prNumber int) {
-	githubEventJSON := []byte(fmt.Sprintf(`{ "pull_request": { "number": %d } }`, prNumber))
+	githubEventJSON := []byte(fmt.Sprintf(`{ "number": %d }`, prNumber))
 	os.WriteFile(gitHubEventFullPath(), githubEventJSON, os.ModePerm) //nolint
 }
 


### PR DESCRIPTION
This reverts commit 149b0c22b2b4d7e53f8d7f6c48aa84f543e230f6 ("Use PR number from pull_request object").

Reverting [as this seems to have caused an error in some scenarios][1].

[1]: https://github.com/agilepathway/label-checker/issues/392