### PR TITLE
Fix bug where Docker image was not tagged latest

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          tags: ${{env.docker_repo}}:${{ needs.tag.outputs.semver }}
+          tags: ${{env.docker_repo}}:${{ needs.tag.outputs.semver }},${{env.docker_repo}}:latest
           platforms: linux/amd64,linux/arm64
           push: true
 
@@ -78,6 +78,7 @@ jobs:
     steps:
 
       - name: Check Docker image for new release is tagged latest
+        # (it is important to have this check to catch any regression, e.g. if we move to a different way of releasing)
         id: check_docker_image_tagged_latest
         # yamllint disable rule:line-length
         run: |


### PR DESCRIPTION
The bug was inadvertently introduced by #405, when we migrated to a later version of the [Docker `build-push-action`][1].

[1]: https://github.com/docker/build-push-action

Fixes #419