### PR TITLE
Fix latest tag check

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -81,8 +81,10 @@ jobs:
         # (it is important to have this check to catch any regression, e.g. if we move to a different way of releasing)
         id: check_docker_image_tagged_latest
         # yamllint disable rule:line-length
+        # we need to pull both docker tags to do the check
         run: |
           docker pull ${{env.docker_repo}}:${{ needs.tag.outputs.semver }}
+          docker pull ${{env.docker_repo}}:latest
           echo "IS_LATEST_TAGGED_CORRECTLY=$(docker image inspect ${{env.docker_repo}}:${{ needs.tag.outputs.semver }} | jq -r '.[] | (.RepoTags) | any( . == "${{env.docker_repo}}:latest") ')" >> "$GITHUB_OUTPUT"
         # yamllint enable rule:line-length
 


### PR DESCRIPTION
Our check that (when we make a new release) the Docker image is tagged with latest as well as the new semver version number, which we added in [v1.6.14][1] was broken. This was because we were not pulling the latest tag docker image during the check, so it was not present. Fixed in this commit.

[1]: https://github.com/agilepathway/label-checker/releases/tag/v1.6.14