### PR TITLE
Enable golangci-lint checks which were not running

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: reviewdog/action-golangci-lint@v1
+      - uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "-c .golangci.yml"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   # enable-all is deprecated, so enable linters individually
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   # enable-all is deprecated, so enable linters individually
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -17,7 +17,7 @@ import (
 	"github.com/agilepathway/label-checker/internal/github/pullrequest"
 )
 
-// Action encapsulates the Label Checker GitHub Action
+// Action encapsulates the Label Checker GitHub Action.
 type Action struct {
 	Stdout     io.Writer // writer to write stdout messages to
 	Stderr     io.Writer // writer to write stderr messages to

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -78,8 +78,6 @@ func (a *Action) trimTrailingNewLine(input string) string {
 
 type check func([]string, bool) (bool, string)
 
-type specified func() []string
-
 func (a *Action) runCheck(chk check, specified []string, prefixMode bool) {
 	if len(specified) == 0 {
 		return

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,7 +117,7 @@ func (a *Action) pullRequestNumber() int {
 	githubEventJSONFile, err := os.Open(filepath.Clean(os.Getenv("GITHUB_EVENT_PATH")))
 	panic.IfError(err)
 	defer githubEventJSONFile.Close() //nolint
-	byteValue, _ := ioutil.ReadAll(githubEventJSONFile)
+	byteValue, _ := io.ReadAll(githubEventJSONFile)
 	panic.IfError(json.Unmarshal(byteValue, &event))
 
 	return event.PullRequest.Number

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -118,11 +118,11 @@ func (a *Action) pullRequestNumber() int {
 }
 
 func (a *Action) outputResult(result string) {
-	label_check_output := fmt.Sprintf("label_check=%s", result)
+	labelCheckOutput := fmt.Sprintf("label_check=%s", result)
 	gitHubOutputFileName := filepath.Clean(os.Getenv("GITHUB_OUTPUT"))
 	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0644)
 	panic.IfError(err)
-	_, err = githubOutputFile.WriteString(label_check_output)
+	_, err = githubOutputFile.WriteString(labelCheckOutput)
 	if err != nil {
 		githubOutputFile.Close()
 		panic.IfError(err)

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -55,6 +55,7 @@ func (a *Action) CheckLabels(stdout, stderr io.Writer) int {
 	}
 
 	a.outputResult("success")
+
 	return 0
 }
 
@@ -68,6 +69,7 @@ func (a *Action) handleFailure() int {
 	if a.allowFailure() {
 		return 0
 	}
+
 	return 1
 }
 
@@ -86,6 +88,7 @@ func (a *Action) runCheck(chk check, specified []string, prefixMode bool) {
 
 	if prefixMode && len(specified) > 1 {
 		a.failMsg += "Currently the label checker only supports checking with one prefix, not multiple."
+
 		return
 	}
 

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -127,7 +127,7 @@ func (a *Action) pullRequestNumber() int {
 func (a *Action) outputResult(result string) {
 	labelCheckOutput := fmt.Sprintf("label_check=%s", result)
 	gitHubOutputFileName := filepath.Clean(os.Getenv("GITHUB_OUTPUT"))
-	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0o644)
+	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec
 	panic.IfError(err)
 	_, err = githubOutputFile.WriteString(labelCheckOutput)
 	if err != nil {

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -127,10 +127,9 @@ func (a *Action) pullRequestNumber() int {
 func (a *Action) outputResult(result string) {
 	labelCheckOutput := fmt.Sprintf("label_check=%s", result)
 	gitHubOutputFileName := filepath.Clean(os.Getenv("GITHUB_OUTPUT"))
-	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0644)
+	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0o644)
 	panic.IfError(err)
 	_, err = githubOutputFile.WriteString(labelCheckOutput)
-
 	if err != nil {
 		closingErr := githubOutputFile.Close()
 

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -64,6 +64,7 @@ func (a *Action) handleFailure() int {
 	a.outputResult("failure")
 	err := errors.New(a.trimTrailingNewLine(a.failMsg))
 	fmt.Fprintln(a.Stderr, "::error::", err)
+
 	if a.allowFailure() {
 		return 0
 	}
@@ -82,11 +83,14 @@ func (a *Action) runCheck(chk check, specified []string, prefixMode bool) {
 	if len(specified) == 0 {
 		return
 	}
+
 	if prefixMode && len(specified) > 1 {
 		a.failMsg += "Currently the label checker only supports checking with one prefix, not multiple."
 		return
 	}
+
 	valid, message := chk(specified, prefixMode)
+
 	if valid {
 		a.successMsg += message + "\n"
 	} else {
@@ -123,6 +127,7 @@ func (a *Action) outputResult(result string) {
 	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0644)
 	panic.IfError(err)
 	_, err = githubOutputFile.WriteString(labelCheckOutput)
+
 	if err != nil {
 		githubOutputFile.Close()
 		panic.IfError(err)

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -132,10 +132,14 @@ func (a *Action) outputResult(result string) {
 	_, err = githubOutputFile.WriteString(labelCheckOutput)
 
 	if err != nil {
-		githubOutputFile.Close()
+		closingErr := githubOutputFile.Close()
+
 		panic.IfError(err)
+		panic.IfError(closingErr)
 	}
-	githubOutputFile.Close()
+
+	err = githubOutputFile.Close()
+	panic.IfError(err)
 }
 
 func (a *Action) token() string {

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -125,11 +125,14 @@ func (a *Action) pullRequestNumber() int {
 }
 
 func (a *Action) outputResult(result string) {
+	const UserReadWriteFilePermission = 0o644
+
 	labelCheckOutput := fmt.Sprintf("label_check=%s", result)
 	gitHubOutputFileName := filepath.Clean(os.Getenv("GITHUB_OUTPUT"))
-	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec
+	githubOutputFile, err := os.OpenFile(gitHubOutputFileName, os.O_APPEND|os.O_WRONLY, UserReadWriteFilePermission) //nolint:gosec,lll
 	panic.IfError(err)
 	_, err = githubOutputFile.WriteString(labelCheckOutput)
+
 	if err != nil {
 		closingErr := githubOutputFile.Close()
 

--- a/internal/github/action.go
+++ b/internal/github/action.go
@@ -92,7 +92,6 @@ func (a *Action) runCheck(chk check, specified []string, prefixMode bool) {
 	} else {
 		a.failMsg += message + "\n"
 	}
-
 }
 
 func (a *Action) repositoryOwner() string {

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -14,25 +14,25 @@ import (
 	"github.com/agilepathway/label-checker/internal/error/panic"
 )
 
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var integration = flag.Bool(
 	"integration",
 	false,
 	"Make calls to real external services.  Requires INPUT_REPO_TOKEN environment variable.")
 
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var enterpriseCloud = flag.Bool(
 	"enterprise-cloud",
 	false,
 	"Run the label checker against GitHub Enterprise Cloud instead of standard GitHub")
 
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var enterpriseServer = flag.Bool(
 	"enterprise-server",
 	false,
 	"Run the label checker against GitHub Enterprise Server instead of standard GitHub")
 
-// nolint: lll
+//nolint:lll
 const (
 	EnvGitHubRepository            = "GITHUB_REPOSITORY"
 	EnvGitHubEventPath             = "GITHUB_EVENT_PATH"
@@ -91,7 +91,7 @@ const (
 
 type specifyChecks func()
 
-// nolint: lll, funlen, dupl
+//nolint:lll,funlen,dupl
 func TestLabelChecks(t *testing.T) {
 	tests := map[string]struct {
 		prNumber       int

--- a/internal/github/action_test.go
+++ b/internal/github/action_test.go
@@ -155,6 +155,7 @@ func TestLabelChecks(t *testing.T) {
 			if len(tc.expectedStderr) > 0 {
 				tc.expectedStderr = "::error:: " + tc.expectedStderr
 			}
+
 			setPullRequestNumber(tc.prNumber)
 			setPrefixMode(tc.prefixMode)
 			tc.specifyChecks()
@@ -269,6 +270,7 @@ func checkLabels() (int, *bytes.Buffer, *bytes.Buffer) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	a := Action{}
+
 	return a.CheckLabels(stdout, stderr), stdout, stderr
 }
 

--- a/internal/github/pullrequest/labels.go
+++ b/internal/github/pullrequest/labels.go
@@ -29,6 +29,7 @@ func (l Labels) HasAllOf(specified []string, prefixMode bool) (bool, string) {
 	if prefixMode {
 		return false, "The label checker does not support prefix checking with `all_of`, as that is not a logical combination." //nolint:lll
 	}
+
 	return l.hasXof(specified, "all", prefixMode)
 }
 

--- a/internal/github/pullrequest/labels.go
+++ b/internal/github/pullrequest/labels.go
@@ -27,7 +27,7 @@ func (l Labels) HasNoneOf(specified []string, prefixMode bool) (bool, string) {
 // all of the specified labels, along with a report describing the result.
 func (l Labels) HasAllOf(specified []string, prefixMode bool) (bool, string) {
 	if prefixMode {
-		return false, "The label checker does not support prefix checking with `all_of`, as that is not a logical combination."
+		return false, "The label checker does not support prefix checking with `all_of`, as that is not a logical combination." //nolint:lll
 	}
 	return l.hasXof(specified, "all", prefixMode)
 }

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -18,6 +18,7 @@ func Contains(slice []string, val string) bool {
 	return false
 }
 
+// StartsWithAnyOf returns true if the given slice starts with any of the given prefixes
 func StartsWithAnyOf(prefixes []string, candidate string) bool {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(candidate, prefix) {


### PR DESCRIPTION
The fix was to update the major version of golangci-lint.
Also fixed the linting warnings which then appeared.