### PR TITLE
Fix goreleaser bug

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -43,9 +43,9 @@ jobs:
           go-version: '1.22.4'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.0.0
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The fix is to specify explicitly a goreleaser version of at least 2.
This should not be necessary in theory, but seems to be in
practice.