### PR TITLE
Fix broken ARM deployments

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -6,13 +6,20 @@ on:  # yamllint disable-line rule:truthy
 jobs:
 
   build_and_push_docker_image:
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-24.04"
+            image: "linux/amd64"
+          - os: "ubuntu-24.04-arm"
+            image: "linux/arm64"
+
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -37,4 +44,4 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.image }}

--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -51,13 +51,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_and_push_docker_image:
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-24.04"
+            image: "linux/amd64"
+          - os: "ubuntu-24.04-arm"
+            image: "linux/arm64"
     needs: tag
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -69,12 +74,15 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: ${{env.docker_repo}}:${{ needs.tag.outputs.semver }},${{env.docker_repo}}:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.image }}
           push: true
 
   check_latest_tag:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     needs: [tag, build_and_push_docker_image]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Check Docker image for new release is tagged latest


### PR DESCRIPTION
[Arm][1] deployments have been broken since the previous release to this one, [v.1.62][2]. The breakage wasn't caused by anything in the previous release itself, but rather by the virtualized [QEMU][3] Docker build and push process having developed a fault.  This was always something in danger of happening, as the QEMU virtualized approch is not as stable as a non virtualized approach.  Fortunately [Arm runners are now available for free in GitHub Actions as of January 16, 2025][4]. So this fix simply replaces QEMU with native ARM runners for the Docker build and push on Arm.

Fixes #480

[1]: https://en.wikipedia.org/wiki/ARM_architecture_family
[2]: https://github.com/agilepathway/label-checker/releases/tag/v1.6.62
[3]: https://github.com/docker/setup-qemu-action
[4]: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/