### PR TITLE
Fix amd64 deployments (but break arm64)

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -56,8 +56,8 @@ jobs:
         include:
           - os: "ubuntu-24.04"
             image: "linux/amd64"
-          - os: "ubuntu-24.04-arm"
-            image: "linux/arm64"
+          # - os: "ubuntu-24.04-arm"
+          #   image: "linux/arm64"
     needs: tag
     name: Build and push image
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The previous release broke amd64 deployments, while adding arm64. Given amd64 is more popular than arm64, this commit reinstates amd64, while unfortunately breaking arm64 again, until we can find a proper fix.