### PR TITLE
Fix reviewdog/action-shellcheck security alert

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@v1.30.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check


### PR DESCRIPTION
There is a security alert on this repository.

# Security Alert

- https://github.com/agilepathway/label-checker/security/advisories/GHSA-3jq5-r82m-qp3q

![スクリーンショット 2025-05-10 7 13 40](https://github.com/user-attachments/assets/3f32dd74-b6c9-4e66-9b5f-0c6df9d39a98)

# Cause

Normally, `reviewdog/action-shellcheck@v1` means the latest of `v1`, but `reviewdog/action-shellcheck` uses `v1` for the specific tag.

- https://github.com/reviewdog/action-shellcheck/tree/v1

![スクリーンショット 2025-05-10 7 11 48](https://github.com/user-attachments/assets/95c88a58-ff01-4f4b-a817-378272eee8a1)

So, `reviewdog/action-shellcheck@v1` doesn't means the latest of `v1`. It points to the oldest version of `v1`.

# Solve

I think the latest version is required to solve this security alert.

Currently, `v1.30.0` is latest.

![スクリーンショット 2025-05-10 7 18 15](https://github.com/user-attachments/assets/905dce14-1029-4d33-b773-024ad559c72e)
